### PR TITLE
test: add integration tests for ssh_args, scp_args and tunnel_handle

### DIFF
--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -348,4 +348,33 @@ mod tests {
         let l_pos = args.iter().position(|a| a == "-l").expect("-l present");
         assert_eq!(args[l_pos + 1], "buser+admin@10.0.0.1");
     }
+
+    // ── invariant destination ─────────────────────────────────────────────────
+
+    /// Garantit que la destination (`user@host`) est toujours le dernier argument,
+    /// quelle que soit la combinaison d'options. Cet invariant est utilisé par
+    /// `build_tunnel_args` et `probe` pour insérer des options juste avant la cible.
+    #[test]
+    fn destination_is_last() {
+        // Direct avec clé + options + port non-standard
+        let mut s = base_server();
+        s.ssh_key = "~/.ssh/id_ed25519".into();
+        s.ssh_options = vec!["StrictHostKeyChecking=no".into(), "-T".into()];
+        s.port = 2222;
+        let args = build_ssh_args(&s, ConnectionMode::Direct, true).unwrap();
+        assert_eq!(args.last().unwrap(), "admin@10.0.0.1");
+
+        // Jump avec clé + port dans l'hôte
+        let mut s2 = base_server();
+        s2.ssh_key = "~/.ssh/id_ed25519".into();
+        s2.host = "10.0.0.1:2222".into();
+        s2.jump_host = Some("juser@jump.example.com:22".into());
+        let args2 = build_ssh_args(&s2, ConnectionMode::Jump, false).unwrap();
+        assert_eq!(args2.last().unwrap(), "admin@10.0.0.1");
+
+        // Direct minimal — destination = dernier arg même sans options
+        let s3 = base_server();
+        let args3 = build_ssh_args(&s3, ConnectionMode::Direct, false).unwrap();
+        assert_eq!(args3.last().unwrap(), "admin@10.0.0.1");
+    }
 }

--- a/tests/scp_args.rs
+++ b/tests/scp_args.rs
@@ -116,14 +116,8 @@ fn jump_host_forwarded() {
 #[test]
 fn jump_missing_host_returns_error() {
     let s = base_server(); // jump_host = None
-    let err = build_scp_args(
-        &s,
-        ConnectionMode::Jump,
-        &ScpDirection::Upload,
-        "f",
-        "r",
-    )
-    .unwrap_err();
+    let err =
+        build_scp_args(&s, ConnectionMode::Jump, &ScpDirection::Upload, "f", "r").unwrap_err();
     assert!(
         err.to_string().contains("Jump host"),
         "message d'erreur attendu, obtenu : {}",
@@ -159,19 +153,23 @@ fn wallix_disabled() {
 fn port_flag_is_uppercase_p() {
     let mut s = base_server();
     s.port = 2222;
-    let args =
-        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    let args = build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
     assert!(args.contains(&"-P".to_string()), "-P (majuscule) attendu");
-    assert!(!args.contains(&"-p".to_string()), "-p (minuscule) inattendu");
+    assert!(
+        !args.contains(&"-p".to_string()),
+        "-p (minuscule) inattendu"
+    );
 }
 
 /// Port 22 par défaut ne doit pas générer de flag `-P`.
 #[test]
 fn no_port_flag_for_default_port_22() {
     let s = base_server();
-    let args =
-        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
-    assert!(!args.contains(&"-P".to_string()), "-P inattendu pour port 22");
+    let args = build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    assert!(
+        !args.contains(&"-P".to_string()),
+        "-P inattendu pour port 22"
+    );
 }
 
 // ─── Clé SSH ──────────────────────────────────────────────────────────────────
@@ -181,8 +179,7 @@ fn no_port_flag_for_default_port_22() {
 fn ssh_key_passed_with_i_flag() {
     let mut s = base_server();
     s.ssh_key = "/home/ops/.ssh/prod_ed25519".into();
-    let args =
-        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    let args = build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
     let i_pos = args.iter().position(|a| a == "-i").expect("-i attendu");
     assert_eq!(args[i_pos + 1], "/home/ops/.ssh/prod_ed25519");
 }
@@ -194,8 +191,7 @@ fn ssh_key_passed_with_i_flag() {
 fn use_system_ssh_config_omits_f_flag() {
     let mut s = base_server();
     s.use_system_ssh_config = true;
-    let args =
-        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    let args = build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
     assert!(
         !args.contains(&"-F".to_string()),
         "-F ne doit pas être présent quand use_system_ssh_config=true"

--- a/tests/scp_args.rs
+++ b/tests/scp_args.rs
@@ -1,0 +1,203 @@
+//! Tests d'intégration pour `ssh::scp::build_scp_args`.
+//!
+//! Vérifie que les arguments `scp` sont correctement construits pour les
+//! différents modes (Direct, Jump, Wallix) et directions (Upload, Download).
+//! Aucun processus `scp` n'est lancé — les tests sont purement en mémoire.
+
+use susshi::config::{ConnectionMode, ResolvedServer};
+use susshi::ssh::scp::{ScpDirection, build_scp_args};
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+fn base_server() -> ResolvedServer {
+    ResolvedServer {
+        namespace: String::new(),
+        group_name: "integration".into(),
+        env_name: "test".into(),
+        name: "srv".into(),
+        host: "192.168.1.10".into(),
+        user: "ops".into(),
+        port: 22,
+        ssh_key: String::new(),
+        ssh_options: vec![],
+        default_mode: ConnectionMode::Direct,
+        jump_host: None,
+        bastion_host: None,
+        bastion_user: None,
+        bastion_template: "{target_user}@%n:SSH:{bastion_user}".into(),
+        use_system_ssh_config: false,
+        probe_filesystems: vec![],
+        tunnels: vec![],
+    }
+}
+
+// ─── Upload ───────────────────────────────────────────────────────────────────
+
+/// Upload direct : le fichier local est la source et la destination distante est en dernier.
+#[test]
+fn upload_direct() {
+    let s = base_server();
+    let args = build_scp_args(
+        &s,
+        ConnectionMode::Direct,
+        &ScpDirection::Upload,
+        "/tmp/dump.sql",
+        "/home/ops/dump.sql",
+    )
+    .unwrap();
+
+    // En upload : args = [..., local_src, remote_dst]
+    assert_eq!(
+        args.last().unwrap(),
+        "ops@192.168.1.10:/home/ops/dump.sql",
+        "destination distante doit être en dernier"
+    );
+    assert_eq!(
+        args[args.len() - 2],
+        "/tmp/dump.sql",
+        "source locale doit précéder la destination"
+    );
+}
+
+// ─── Download ─────────────────────────────────────────────────────────────────
+
+/// Download direct : la source distante est en avant-dernier, la destination locale en dernier.
+#[test]
+fn download_direct() {
+    let s = base_server();
+    let args = build_scp_args(
+        &s,
+        ConnectionMode::Direct,
+        &ScpDirection::Download,
+        "/tmp/dump.sql",
+        "/home/ops/dump.sql",
+    )
+    .unwrap();
+
+    // En download : args = [..., remote_src, local_dst]
+    assert_eq!(
+        args.last().unwrap(),
+        "/tmp/dump.sql",
+        "destination locale doit être en dernier"
+    );
+    assert_eq!(
+        args[args.len() - 2],
+        "ops@192.168.1.10:/home/ops/dump.sql",
+        "source distante doit précéder la destination locale"
+    );
+}
+
+// ─── Jump ─────────────────────────────────────────────────────────────────────
+
+/// Mode Jump : `-J user@host` transmis à `scp` pour le forward.
+#[test]
+fn jump_host_forwarded() {
+    let mut s = base_server();
+    s.jump_host = Some("jops@jump.infra.example.com".into());
+    let args = build_scp_args(
+        &s,
+        ConnectionMode::Jump,
+        &ScpDirection::Upload,
+        "file.txt",
+        "/tmp/file.txt",
+    )
+    .unwrap();
+
+    let j_pos = args.iter().position(|a| a == "-J").expect("-J attendu");
+    assert_eq!(args[j_pos + 1], "jops@jump.infra.example.com");
+    // La destination distante reste en dernier
+    assert!(
+        args.last().unwrap().starts_with("ops@192.168.1.10:"),
+        "destination distante incorrecte"
+    );
+}
+
+/// Mode Jump sans `jump_host` configuré → erreur explicite.
+#[test]
+fn jump_missing_host_returns_error() {
+    let s = base_server(); // jump_host = None
+    let err = build_scp_args(
+        &s,
+        ConnectionMode::Jump,
+        &ScpDirection::Upload,
+        "f",
+        "r",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("Jump host"),
+        "message d'erreur attendu, obtenu : {}",
+        err
+    );
+}
+
+// ─── Wallix ───────────────────────────────────────────────────────────────────
+
+/// Mode Wallix est systématiquement refusé (le bastion Wallix gère les transferts lui-même).
+#[test]
+fn wallix_disabled() {
+    let s = base_server();
+    let err = build_scp_args(
+        &s,
+        ConnectionMode::Wallix,
+        &ScpDirection::Upload,
+        "file.txt",
+        "/tmp/file.txt",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("Wallix"),
+        "erreur Wallix attendue, obtenu : {}",
+        err
+    );
+}
+
+// ─── Port ─────────────────────────────────────────────────────────────────────
+
+/// `scp` utilise `-P` (majuscule) pour le port, contrairement à `ssh` qui utilise `-p`.
+#[test]
+fn port_flag_is_uppercase_p() {
+    let mut s = base_server();
+    s.port = 2222;
+    let args =
+        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    assert!(args.contains(&"-P".to_string()), "-P (majuscule) attendu");
+    assert!(!args.contains(&"-p".to_string()), "-p (minuscule) inattendu");
+}
+
+/// Port 22 par défaut ne doit pas générer de flag `-P`.
+#[test]
+fn no_port_flag_for_default_port_22() {
+    let s = base_server();
+    let args =
+        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    assert!(!args.contains(&"-P".to_string()), "-P inattendu pour port 22");
+}
+
+// ─── Clé SSH ──────────────────────────────────────────────────────────────────
+
+/// La clé SSH est passée avec `-i`.
+#[test]
+fn ssh_key_passed_with_i_flag() {
+    let mut s = base_server();
+    s.ssh_key = "/home/ops/.ssh/prod_ed25519".into();
+    let args =
+        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    let i_pos = args.iter().position(|a| a == "-i").expect("-i attendu");
+    assert_eq!(args[i_pos + 1], "/home/ops/.ssh/prod_ed25519");
+}
+
+// ─── Config système SSH ───────────────────────────────────────────────────────
+
+/// `use_system_ssh_config: true` supprime le `-F /dev/null`.
+#[test]
+fn use_system_ssh_config_omits_f_flag() {
+    let mut s = base_server();
+    s.use_system_ssh_config = true;
+    let args =
+        build_scp_args(&s, ConnectionMode::Direct, &ScpDirection::Upload, "f", "r").unwrap();
+    assert!(
+        !args.contains(&"-F".to_string()),
+        "-F ne doit pas être présent quand use_system_ssh_config=true"
+    );
+}

--- a/tests/ssh_args.rs
+++ b/tests/ssh_args.rs
@@ -1,0 +1,226 @@
+//! Tests d'intégration pour `ssh::client::build_ssh_args`.
+//!
+//! Ces tests exercent la fonction `build_ssh_args` depuis l'API publique afin
+//! de garantir que les scénarios courants produisent les arguments SSH attendus.
+//! Aucun serveur SSH réel n'est requis — tout est purement en mémoire.
+
+use susshi::config::{ConnectionMode, ResolvedServer};
+use susshi::ssh::client::build_ssh_args;
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+fn base_server() -> ResolvedServer {
+    ResolvedServer {
+        namespace: String::new(),
+        group_name: "integration".into(),
+        env_name: "test".into(),
+        name: "srv".into(),
+        host: "192.168.1.10".into(),
+        user: "ops".into(),
+        port: 22,
+        ssh_key: String::new(),
+        ssh_options: vec![],
+        default_mode: ConnectionMode::Direct,
+        jump_host: None,
+        bastion_host: None,
+        bastion_user: None,
+        bastion_template: "{target_user}@%n:SSH:{bastion_user}".into(),
+        use_system_ssh_config: false,
+        probe_filesystems: vec![],
+        tunnels: vec![],
+    }
+}
+
+// ─── Mode Direct ─────────────────────────────────────────────────────────────
+
+/// Un serveur minimal produit `-F /dev/null` + `user@host` sans options superflues.
+#[test]
+fn direct_minimal() {
+    let s = base_server();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+
+    assert!(args.contains(&"-F".to_string()), "-F attendu");
+    assert!(args.contains(&"/dev/null".to_string()), "/dev/null attendu");
+    assert!(
+        args.contains(&"ops@192.168.1.10".to_string()),
+        "destination attendue"
+    );
+    // Pas d'options superflues pour un serveur port-22 sans clé
+    assert!(!args.contains(&"-p".to_string()), "-p inattendu pour port 22");
+    assert!(!args.contains(&"-i".to_string()), "-i inattendu sans clé");
+    assert!(!args.contains(&"-v".to_string()), "-v inattendu");
+}
+
+/// La clé SSH est passée avec `-i` et le tilde est expandé.
+#[test]
+fn direct_with_key() {
+    let mut s = base_server();
+    s.ssh_key = "~/.ssh/id_ed25519".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+
+    let i_pos = args.iter().position(|a| a == "-i").expect("-i attendu");
+    // Le tilde doit avoir été expandé (shellexpand::tilde)
+    assert!(
+        !args[i_pos + 1].starts_with('~'),
+        "le tilde doit être expandé"
+    );
+    assert!(
+        args[i_pos + 1].ends_with("/.ssh/id_ed25519"),
+        "chemin de clé incorrect"
+    );
+}
+
+/// Un port non-standard est ajouté avec `-p`.
+#[test]
+fn direct_with_port() {
+    let mut s = base_server();
+    s.port = 2222;
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+
+    let p_pos = args.iter().position(|a| a == "-p").expect("-p attendu");
+    assert_eq!(args[p_pos + 1], "2222", "valeur du port incorrecte");
+    // La destination ne doit pas contenir le port
+    assert_eq!(
+        args.last().unwrap(),
+        "ops@192.168.1.10",
+        "destination incorrecte"
+    );
+}
+
+/// Un port embarqué dans la chaîne `host:port` est extrait et transmis via `-p`.
+#[test]
+fn direct_with_port_in_host_string() {
+    let mut s = base_server();
+    s.host = "192.168.1.10:2222".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+
+    assert!(args.contains(&"-p".to_string()), "-p attendu");
+    assert!(args.contains(&"2222".to_string()), "valeur 2222 attendue");
+    // La destination doit utiliser le host sans le port
+    assert_eq!(args.last().unwrap(), "ops@192.168.1.10");
+}
+
+/// Les `ssh_options` scalaires sont préfixées par `-o`, les flags (commençant par `-`) passent tels quels.
+#[test]
+fn direct_with_options() {
+    let mut s = base_server();
+    s.ssh_options = vec!["ServerAliveInterval=30".into(), "-T".into()];
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+
+    let o_pos = args.iter().position(|a| a == "-o").expect("-o attendu");
+    assert_eq!(
+        args[o_pos + 1], "ServerAliveInterval=30",
+        "option scalaire incorrecte"
+    );
+    assert!(
+        args.contains(&"-T".to_string()),
+        "flag -T doit passer tel quel"
+    );
+}
+
+/// `use_system_ssh_config: true` supprime le `-F /dev/null`.
+#[test]
+fn system_ssh_config() {
+    let mut s = base_server();
+    s.use_system_ssh_config = true;
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+
+    assert!(
+        !args.contains(&"-F".to_string()),
+        "-F ne doit pas être présent quand use_system_ssh_config=true"
+    );
+}
+
+// ─── Mode Jump ───────────────────────────────────────────────────────────────
+
+/// Mode Jump correct : `-J user@host` suivi de la destination cible.
+#[test]
+fn jump_host() {
+    let mut s = base_server();
+    s.jump_host = Some("jops@jump.infra.example.com".into());
+    let args = build_ssh_args(&s, ConnectionMode::Jump, false).unwrap();
+
+    let j_pos = args.iter().position(|a| a == "-J").expect("-J attendu");
+    assert_eq!(args[j_pos + 1], "jops@jump.infra.example.com");
+    assert_eq!(args.last().unwrap(), "ops@192.168.1.10");
+}
+
+/// Mode Jump sans `jump_host` configuré retourne une erreur explicite.
+#[test]
+fn jump_no_host() {
+    let s = base_server(); // jump_host = None
+    let err = build_ssh_args(&s, ConnectionMode::Jump, false).unwrap_err();
+    assert!(
+        err.to_string().contains("Jump host not configured"),
+        "message d'erreur attendu, obtenu : {}",
+        err
+    );
+}
+
+// ─── Mode Wallix ─────────────────────────────────────────────────────────────
+
+/// Mode Wallix : le template est correctement substitué dans `-l`.
+#[test]
+fn wallix_template() {
+    let mut s = base_server();
+    s.bastion_host = Some("bastion.corp.example.com".into());
+    s.bastion_user = Some("bops".into());
+    // template par défaut : {target_user}@%n:SSH:{bastion_user}
+    let args = build_ssh_args(&s, ConnectionMode::Wallix, false).unwrap();
+
+    let l_pos = args.iter().position(|a| a == "-l").expect("-l attendu");
+    assert_eq!(
+        args[l_pos + 1], "ops@192.168.1.10:SSH:bops",
+        "template Wallix incorrect"
+    );
+    assert!(
+        args.contains(&"bastion.corp.example.com".to_string()),
+        "bastion host absent"
+    );
+}
+
+/// Mode Wallix sans `bastion_host` retourne une erreur explicite.
+#[test]
+fn wallix_no_host() {
+    let s = base_server(); // bastion_host = None
+    let err = build_ssh_args(&s, ConnectionMode::Wallix, false).unwrap_err();
+    assert!(
+        err.to_string().contains("Wallix host not configured"),
+        "message d'erreur attendu, obtenu : {}",
+        err
+    );
+}
+
+// ─── Invariant destination ────────────────────────────────────────────────────
+
+/// La destination (`user@host`) est **toujours** le dernier argument de la liste,
+/// quels que soient les modes, clés, options et ports configurés.
+///
+/// Cet invariant est critique : `build_tunnel_args` et `probe` s'en servent pour
+/// insérer leurs propres options juste avant la cible en faisant un `args.pop()`.
+#[test]
+fn destination_is_last() {
+    // Direct + clé + options + port non-standard + verbose
+    let mut s = base_server();
+    s.ssh_key = "~/.ssh/id_ed25519".into();
+    s.ssh_options = vec!["StrictHostKeyChecking=no".into(), "-T".into(), "BatchMode=yes".into()];
+    s.port = 22222;
+    let args = build_ssh_args(&s, ConnectionMode::Direct, true).unwrap();
+    assert_eq!(
+        args.last().unwrap(),
+        "ops@192.168.1.10",
+        "Direct : destination doit être en dernière position"
+    );
+
+    // Jump + clé + port dans l'hôte
+    let mut s2 = base_server();
+    s2.ssh_key = "~/.ssh/prod_ed25519".into();
+    s2.host = "192.168.1.10:22".into();
+    s2.jump_host = Some("jops@jump.example.com:2222".into());
+    let args2 = build_ssh_args(&s2, ConnectionMode::Jump, false).unwrap();
+    assert_eq!(
+        args2.last().unwrap(),
+        "ops@192.168.1.10",
+        "Jump : destination doit être en dernière position"
+    );
+}

--- a/tests/ssh_args.rs
+++ b/tests/ssh_args.rs
@@ -46,7 +46,10 @@ fn direct_minimal() {
         "destination attendue"
     );
     // Pas d'options superflues pour un serveur port-22 sans clé
-    assert!(!args.contains(&"-p".to_string()), "-p inattendu pour port 22");
+    assert!(
+        !args.contains(&"-p".to_string()),
+        "-p inattendu pour port 22"
+    );
     assert!(!args.contains(&"-i".to_string()), "-i inattendu sans clé");
     assert!(!args.contains(&"-v".to_string()), "-v inattendu");
 }
@@ -109,7 +112,8 @@ fn direct_with_options() {
 
     let o_pos = args.iter().position(|a| a == "-o").expect("-o attendu");
     assert_eq!(
-        args[o_pos + 1], "ServerAliveInterval=30",
+        args[o_pos + 1],
+        "ServerAliveInterval=30",
         "option scalaire incorrecte"
     );
     assert!(
@@ -170,7 +174,8 @@ fn wallix_template() {
 
     let l_pos = args.iter().position(|a| a == "-l").expect("-l attendu");
     assert_eq!(
-        args[l_pos + 1], "ops@192.168.1.10:SSH:bops",
+        args[l_pos + 1],
+        "ops@192.168.1.10:SSH:bops",
         "template Wallix incorrect"
     );
     assert!(
@@ -203,7 +208,11 @@ fn destination_is_last() {
     // Direct + clé + options + port non-standard + verbose
     let mut s = base_server();
     s.ssh_key = "~/.ssh/id_ed25519".into();
-    s.ssh_options = vec!["StrictHostKeyChecking=no".into(), "-T".into(), "BatchMode=yes".into()];
+    s.ssh_options = vec![
+        "StrictHostKeyChecking=no".into(),
+        "-T".into(),
+        "BatchMode=yes".into(),
+    ];
     s.port = 22222;
     let args = build_ssh_args(&s, ConnectionMode::Direct, true).unwrap();
     assert_eq!(

--- a/tests/tunnel_handle.rs
+++ b/tests/tunnel_handle.rs
@@ -109,13 +109,15 @@ fn build_tunnel_args_structure() {
     // -L localPort:remoteHost:remotePort
     let l_pos = args.iter().position(|a| a == "-L").expect("-L attendu");
     assert_eq!(
-        args[l_pos + 1], "5433:127.0.0.1:5432",
+        args[l_pos + 1],
+        "5433:127.0.0.1:5432",
         "format -L incorrect"
     );
 
     // ExitOnForwardFailure doit être activé
     assert!(
-        args.iter().any(|a: &String| a.contains("ExitOnForwardFailure")),
+        args.iter()
+            .any(|a: &String| a.contains("ExitOnForwardFailure")),
         "ExitOnForwardFailure attendu"
     );
 
@@ -193,7 +195,8 @@ fn build_tunnel_args_l_flag_format_with_named_host() {
     let args = build_tunnel_args(&s, ConnectionMode::Direct, &t).unwrap();
     let l_pos = args.iter().position(|a| a == "-L").expect("-L attendu");
     assert_eq!(
-        args[l_pos + 1], "15432:db.internal.example.com:5432",
+        args[l_pos + 1],
+        "15432:db.internal.example.com:5432",
         "format -L incorrect avec nom d'hôte"
     );
 }

--- a/tests/tunnel_handle.rs
+++ b/tests/tunnel_handle.rs
@@ -1,0 +1,199 @@
+//! Tests d'intégration pour `ssh::tunnel` — construction des arguments et
+//! cycle de vie d'un `TunnelHandle`.
+//!
+//! Aucun serveur SSH réel n'est requis. Les tests `TunnelHandle::new` +
+//! `is_running` + `poll` sont purement en mémoire. Les tests sur
+//! `build_tunnel_args` vérifient la structure des arguments sans lancer `ssh`.
+
+use susshi::config::{ConnectionMode, ResolvedServer, TunnelConfig};
+use susshi::ssh::tunnel::{TunnelHandle, TunnelStatus, build_tunnel_args};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn base_server() -> ResolvedServer {
+    ResolvedServer {
+        namespace: String::new(),
+        group_name: "integration".into(),
+        env_name: "test".into(),
+        name: "srv".into(),
+        host: "192.168.1.10".into(),
+        user: "ops".into(),
+        port: 22,
+        ssh_key: String::new(),
+        ssh_options: vec![],
+        default_mode: ConnectionMode::Direct,
+        jump_host: None,
+        bastion_host: None,
+        bastion_user: None,
+        bastion_template: "{target_user}@%n:SSH:{bastion_user}".into(),
+        use_system_ssh_config: false,
+        probe_filesystems: vec![],
+        tunnels: vec![],
+    }
+}
+
+fn pg_tunnel() -> TunnelConfig {
+    TunnelConfig {
+        local_port: 5433,
+        remote_host: "127.0.0.1".into(),
+        remote_port: 5432,
+        label: "PostgreSQL".into(),
+    }
+}
+
+// ─── TunnelHandle — cycle de vie ─────────────────────────────────────────────
+
+/// Un handle créé via `TunnelHandle::new` est dans l'état `Idle` par défaut.
+#[test]
+fn new_is_idle() {
+    let h = TunnelHandle::new(pg_tunnel(), Some(0), 0);
+    assert!(
+        matches!(h.status, TunnelStatus::Idle),
+        "statut attendu : Idle, obtenu : {:?}",
+        h.status
+    );
+}
+
+/// `is_running()` retourne `false` pour un handle `Idle`.
+#[test]
+fn is_running_false_when_idle() {
+    let h = TunnelHandle::new(pg_tunnel(), None, 0);
+    assert!(!h.is_running(), "is_running doit retourner false pour Idle");
+}
+
+/// `poll()` sur un handle `Idle` (sans processus enfant) retourne `false`
+/// sans paniquer ni modifier le statut.
+#[test]
+fn poll_returns_false_without_child() {
+    let mut h = TunnelHandle::new(pg_tunnel(), None, 0);
+    let became_dead = h.poll();
+    assert!(!became_dead, "poll sans child doit retourner false");
+    assert!(
+        matches!(h.status, TunnelStatus::Idle),
+        "le statut ne doit pas changer après poll sur Idle"
+    );
+}
+
+/// Les champs `config`, `yaml_index` et `user_idx` sont correctement stockés.
+#[test]
+fn new_stores_config_and_indices() {
+    let t = pg_tunnel();
+    let h = TunnelHandle::new(t.clone(), Some(3), 7);
+    assert_eq!(h.config.local_port, t.local_port);
+    assert_eq!(h.config.remote_host, t.remote_host);
+    assert_eq!(h.config.remote_port, t.remote_port);
+    assert_eq!(h.yaml_index, Some(3));
+    assert_eq!(h.user_idx, 7);
+}
+
+/// Un handle sans origine YAML (`yaml_index = None`) est valide.
+#[test]
+fn new_without_yaml_index() {
+    let h = TunnelHandle::new(pg_tunnel(), None, 0);
+    assert!(h.yaml_index.is_none(), "yaml_index doit être None");
+}
+
+// ─── build_tunnel_args — structure des arguments ─────────────────────────────
+
+/// Les arguments d'un tunnel direct contiennent `-N`, `-L port:host:port`
+/// et la destination en dernière position.
+#[test]
+fn build_tunnel_args_structure() {
+    let s = base_server();
+    let t = pg_tunnel();
+    let args = build_tunnel_args(&s, ConnectionMode::Direct, &t).unwrap();
+
+    // -N : pas de commande distante
+    assert!(args.contains(&"-N".to_string()), "-N attendu");
+
+    // -L localPort:remoteHost:remotePort
+    let l_pos = args.iter().position(|a| a == "-L").expect("-L attendu");
+    assert_eq!(
+        args[l_pos + 1], "5433:127.0.0.1:5432",
+        "format -L incorrect"
+    );
+
+    // ExitOnForwardFailure doit être activé
+    assert!(
+        args.iter().any(|a: &String| a.contains("ExitOnForwardFailure")),
+        "ExitOnForwardFailure attendu"
+    );
+
+    // La destination reste toujours en dernière position (invariant critique)
+    assert_eq!(
+        args.last().unwrap(),
+        "ops@192.168.1.10",
+        "destination doit être en dernière position"
+    );
+}
+
+/// Mode Jump : `-J` est présent et la destination reste en dernière position.
+#[test]
+fn build_tunnel_args_jump_keeps_j_and_destination_last() {
+    let mut s = base_server();
+    s.jump_host = Some("jops@jump.example.com".into());
+    let t = pg_tunnel();
+    let args = build_tunnel_args(&s, ConnectionMode::Jump, &t).unwrap();
+
+    assert!(args.contains(&"-J".to_string()), "-J attendu en mode Jump");
+    assert!(args.contains(&"-N".to_string()), "-N attendu");
+    assert_eq!(
+        args.last().unwrap(),
+        "ops@192.168.1.10",
+        "destination doit être en dernière position"
+    );
+}
+
+/// Mode Wallix est refusé (tunnels non disponibles via Wallix).
+#[test]
+fn build_tunnel_args_wallix_rejected() {
+    let s = base_server();
+    let err = build_tunnel_args(&s, ConnectionMode::Wallix, &pg_tunnel()).unwrap_err();
+    assert!(
+        err.to_string().contains("Wallix"),
+        "erreur Wallix attendue, obtenu : {}",
+        err
+    );
+}
+
+/// Les ssh_options du serveur (options et flags) précèdent toujours la destination.
+#[test]
+fn build_tunnel_args_options_before_destination() {
+    let mut s = base_server();
+    s.ssh_key = "~/.ssh/id_ed25519".into();
+    s.ssh_options = vec!["ServerAliveInterval=30".into()];
+    let t = pg_tunnel();
+    let args = build_tunnel_args(&s, ConnectionMode::Direct, &t).unwrap();
+
+    let dest_pos = args
+        .iter()
+        .rposition(|a| a == "ops@192.168.1.10")
+        .expect("destination absente");
+    let opt_pos = args
+        .iter()
+        .position(|a| a == "ServerAliveInterval=30")
+        .expect("option absente");
+
+    assert!(
+        opt_pos < dest_pos,
+        "les options SSH doivent précéder la destination"
+    );
+}
+
+/// Le format du flag `-L` est `localPort:remoteHost:remotePort`.
+#[test]
+fn build_tunnel_args_l_flag_format_with_named_host() {
+    let s = base_server();
+    let t = TunnelConfig {
+        local_port: 15432,
+        remote_host: "db.internal.example.com".into(),
+        remote_port: 5432,
+        label: "DB interne".into(),
+    };
+    let args = build_tunnel_args(&s, ConnectionMode::Direct, &t).unwrap();
+    let l_pos = args.iter().position(|a| a == "-L").expect("-L attendu");
+    assert_eq!(
+        args[l_pos + 1], "15432:db.internal.example.com:5432",
+        "format -L incorrect avec nom d'hôte"
+    );
+}


### PR DESCRIPTION
## Contexte

Étape 1 de la roadmap v0.11.0 — tests d'intégration manquants sur les modules SSH critiques.

## Changements

### Nouveaux fichiers de tests d'intégration

- **`tests/ssh_args.rs`** (11 tests) — `build_ssh_args` : Direct minimal, clé SSH avec expansion du tilde, port via champ `port`, port embarqué dans la chaîne hôte, `ssh_options` (scalaires + flags), `use_system_ssh_config`, Jump avec et sans `jump_host`, Wallix template + `bastion_host` manquant, invariant destination-en-dernier
- **`tests/scp_args.rs`** (9 tests) — `build_scp_args` : Upload/Download direct, Jump avec forwarding, Jump sans `jump_host`, Wallix désactivé, flag `-P` (majuscule), port 22 par défaut, clé SSH, `use_system_ssh_config`
- **`tests/tunnel_handle.rs`** (10 tests) — `build_tunnel_args` + cycle de vie `TunnelHandle` : `new_is_idle`, `is_running`, `poll` sans child, stockage des champs, format `-L port:host:port`, mode Jump, Wallix rejeté, options avant destination, invariant destination-en-dernier

### Modification `src/ssh/client.rs`

Ajout du test `destination_is_last` (listé dans la roadmap mais absent du module) : vérifie l'invariant critique utilisé par `build_tunnel_args` et `probe` sur trois scénarios (Direct complet, Jump avec port dans l'hôte, Direct minimal).

## Résultat

```
145 tests, 0 échec — cargo clippy -- -D warnings : 0 warning
```
