### PR TITLE
docs: README, full_config.yaml and CHANGELOG for v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Groups → Ansible `children`, environments → sub-groups, namespaces (includes) → top-level groups.
   - `--export-output <file>` writes to a file; omit for stdout.
   - `--export-filter <query>` accepts the same text + `#tag` syntax as the TUI search bar.
+- **Templating / variable interpolation** (`_vars` section): define reusable scalar variables at the top of any YAML file (main or included) and interpolate them with `{{ var }}` in any string field (`host`, `user`, `ssh_key`, etc.).
+  - Each file has its own `_vars` scope — variables do not leak into included files or vice versa.
+  - Built-in `{{ index }}`: automatically set to the 1-based position of a server within its parent list, making it easy to declare a fleet of homogeneous servers without copy-pasting (`name: "worker-{{ index }}"`, `host: "10.0.1.{{ index }}"`). Resets to 1 for each list independently.
+  - Referencing an undefined variable leaves the `{{ var }}` placeholder intact and emits a non-blocking warning at startup.
+- **Tags and advanced search filtering** (`tags:` key): attach a list of tags to any server or group.
+  - Search with `#tag` prefix in the TUI search bar (`/`) to filter by tag.
+  - Multiple tags in a query perform an AND filter: `#prod #k8s` shows servers that have **both** tags.
+  - Mixed queries like `api #prod` combine a text match on name/host **and** a tag filter.
+  - `defaults.default_filter`: set an initial search filter applied at startup (e.g. `default_filter: "#prod"`). Clear it with `Esc`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Import `~/.ssh/config`** (`--import-ssh-config`): parse an OpenSSH client config file (including recursive `Include` directives) and generate a susshi-compatible YAML block. Supports `--ssh-config-path <path>`, `--output <file>`, and `--dry-run`. Mapping: `Host`/`HostName`, `User`, `Port`, `IdentityFile`, `ProxyJump` (grouped as jump-mode servers), `ServerAliveInterval`. Wildcard entries (`Host *`) are skipped with a comment; `ProxyCommand` entries produce a warning.
+- **ControlMaster SSH multiplexing**: new optional keys in `defaults` (and per-server overrides via inheritance):
+  - `control_master: true` — activate connection multiplexing.
+  - `control_path: "~/.ssh/ctl/%h_%p_%r"` — socket path (tilde-expanded; parent directory auto-created).
+  - `control_persist: "10m"` — keep-alive duration after the last client disconnects.
+  When active, `build_ssh_args()` injects `-o ControlMaster=auto -o ControlPath=… -o ControlPersist=…` before the destination. Silently disabled in Wallix mode.
+- **Hooks `pre_connect` / `post_disconnect`**: run shell scripts before and after each SSH connection.
+  - Configurable globally in `defaults` or overridden per server (`pre_connect_hook`, `post_disconnect_hook`).
+  - The hook receives `SUSSHI_SERVER`, `SUSSHI_HOST`, `SUSSHI_USER`, `SUSSHI_PORT`, `SUSSHI_MODE` as environment variables.
+  - A non-zero exit code from `pre_connect_hook` cancels the connection with an error message.
+  - `hook_timeout_secs` (default: `5`) prevents blocking on slow hooks.
+- **Export Ansible inventory** (`--export ansible`): generate an Ansible YAML inventory from the susshi config.
+  - Groups → Ansible `children`, environments → sub-groups, namespaces (includes) → top-level groups.
+  - `--export-output <file>` writes to a file; omit for stdout.
+  - `--export-filter <query>` accepts the same text + `#tag` syntax as the TUI search bar.
+
 ---
 
 ## [0.10.2] — 2026-03-02

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
   - `-v/--verbose` — enable SSH verbose output.
 - **Advanced Search**:
   - **Multi-field Search**: Search by server name OR hostname.
+  - **Tag Filtering**: Use `#tag` prefix to filter by tag (e.g. `#prod`). Multiple tags perform an AND filter. Mix text and tags freely (e.g. `api #prod`).
   - **Live Results Counter**: See matching servers in real-time (e.g., "45 / 387 servers").
   - **Visual Feedback**: Color-coded borders (sapphire during search, green for results, red for no match).
   - **Smart Expansion**: Auto-expands groups when searching.
+  - **Default Filter**: Set `defaults.default_filter` in your config to pre-apply a filter at startup.
 - **Interactive TUI**:
   - **Mouse Support**: Click to select, double-click to connect.
   - **Configurable Theme**: Choose from four Catppuccin flavors — `latte`, `frappe`, `macchiato`, or `mocha` (default) via `defaults.theme` in your config.
@@ -48,6 +50,13 @@
 - **ControlMaster SSH multiplexing**: set `control_master: true` in `defaults` to reuse SSH connections across sessions. susshi injects `-o ControlMaster=auto -o ControlPath=… -o ControlPersist=…` automatically and creates the socket directory if needed. Configurable via `control_path` (default: `~/.ssh/ctl/%h_%p_%r`) and `control_persist` (default: `10m`). Silently disabled in Wallix mode.
 - **Hooks `pre_connect_hook` / `post_disconnect_hook`**: run shell scripts before/after each SSH connection. Configurable globally in `defaults` or per server. Variables `SUSSHI_SERVER`, `SUSSHI_HOST`, `SUSSHI_USER`, `SUSSHI_PORT`, `SUSSHI_MODE` are passed as environment variables. A non-zero exit from `pre_connect_hook` cancels the connection. `hook_timeout_secs` (default: `5`) controls the kill timeout.
 - **Export Ansible inventory** (`--export ansible`): generate a YAML Ansible inventory from your susshi config. Groups → `children`, environments → sub-groups, namespaces → top-level groups. Use `--export-output <file>` to write to a file, and `--export-filter <query>` to apply the same text + `#tag` filter as the TUI search.
+- **Templating / variable interpolation**: define a `_vars:` section at the top of any YAML file and reference variables with `{{ var }}` in any string field. Scoped per file — variables in an included file do not pollute the parent. Undefined variables emit a non-blocking warning and are left as-is.
+  - Built-in `{{ index }}`: automatically expands to the 1-based position of a server within its list, enabling compact fleet declarations (`name: "worker-{{ index }}"`, `host: "10.0.1.{{ index }}"`). Each list resets the counter independently.
+- **Tags and advanced search** (`tags:` key on servers and groups): filter servers by semantic labels directly in the TUI.
+  - `#tag` prefix in the search bar filters by tag.
+  - Multiple `#tag` tokens perform an AND filter.
+  - Mix text and tags: `api #prod` = name contains "api" **AND** tag `prod` is present.
+  - `defaults.default_filter` sets a filter active at startup (cleared with `Esc`).
 
 ## 🚀 Installation
 
@@ -221,6 +230,9 @@ jump:
   - `control_master` / `control_path` / `control_persist`: Enable SSH ControlMaster multiplexing (reuse connections). `control_path` is tilde-expanded and its parent directory is created automatically. Not active in Wallix mode.
   - `pre_connect_hook` / `post_disconnect_hook`: Path to a shell script run before/after each connection (tilde-expanded). Receives `SUSSHI_*` environment variables. Non-zero exit from `pre_connect_hook` aborts the connection. Can also be set per-server.
   - `hook_timeout_secs`: Maximum seconds to wait for a hook to exit before killing it (default: `5`).
+  - `default_filter`: Pre-apply a TUI search filter at startup (e.g. `default_filter: "#prod"`). The user can clear it with `Esc`.
+- **`_vars`**: *(optional, top-level)* A map of scalar variables available for interpolation in any string field of the same file via `{{ var }}`. Scoped to the file — variables do not propagate across `includes`. Referencing an undefined variable emits a non-blocking warning and leaves the placeholder intact.
+- **`tags`**: *(optional, on a server or group)* A list of string labels used for filtering in the TUI search bar and in `--export-filter`.
 - **`groups`**: The top-level hierarchy. Can contain `environments` or direct `servers`.
   - Can override any default setting including `mode`.
 - **`environments`**: A sub-grouping under a Group.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@
 - **SCP File Transfer** (`s`): Press `s` to open the SCP form. Choose upload or download, fill in the local and remote paths, and watch real-time transfer progress directly in the TUI. The transfer runs via a PTY so OpenSSH streams percentage updates live.
 - **In-TUI Error Screen**: Connection errors are displayed as an overlay instead of crashing — press `Enter`/`Esc`/`q` to dismiss.
 - **Smart Sorting**: Automatically sorts groups and servers alphabetically.
+- **Import `~/.ssh/config`** (`--import-ssh-config`): parse an OpenSSH client config file (including recursive `Include` directives) and emit a susshi-compatible YAML block. Supports `--ssh-config-path <path>`, `--output <file>`, and `--dry-run` (preview without writing). `ProxyJump` entries are automatically converted to jump-mode servers.
+- **ControlMaster SSH multiplexing**: set `control_master: true` in `defaults` to reuse SSH connections across sessions. susshi injects `-o ControlMaster=auto -o ControlPath=… -o ControlPersist=…` automatically and creates the socket directory if needed. Configurable via `control_path` (default: `~/.ssh/ctl/%h_%p_%r`) and `control_persist` (default: `10m`). Silently disabled in Wallix mode.
+- **Hooks `pre_connect_hook` / `post_disconnect_hook`**: run shell scripts before/after each SSH connection. Configurable globally in `defaults` or per server. Variables `SUSSHI_SERVER`, `SUSSHI_HOST`, `SUSSHI_USER`, `SUSSHI_PORT`, `SUSSHI_MODE` are passed as environment variables. A non-zero exit from `pre_connect_hook` cancels the connection. `hook_timeout_secs` (default: `5`) controls the kill timeout.
+- **Export Ansible inventory** (`--export ansible`): generate a YAML Ansible inventory from your susshi config. Groups → `children`, environments → sub-groups, namespaces → top-level groups. Use `--export-output <file>` to write to a file, and `--export-filter <query>` to apply the same text + `#tag` filter as the TUI search.
 
 ## 🚀 Installation
 
@@ -214,6 +218,9 @@ jump:
   - `use_system_ssh_config`: Set to `true` to honour `~/.ssh/config` instead of passing `-F /dev/null`. Defaults to `false`.
   - `probe_filesystems`: List of extra mount points to inspect during the quick diagnostic (`d`). Uses **additive inheritance**: each level appends its paths to the parent list (unlike `user` or `ssh_key` which replace). If a path is not mounted on the target server a yellow `⚠` warning is shown instead of a progress bar.
   - `keep_open`: Set to `true` to reopen the TUI automatically after a connection closes. Defaults to `false` (historical behaviour: susshi exits after connecting).
+  - `control_master` / `control_path` / `control_persist`: Enable SSH ControlMaster multiplexing (reuse connections). `control_path` is tilde-expanded and its parent directory is created automatically. Not active in Wallix mode.
+  - `pre_connect_hook` / `post_disconnect_hook`: Path to a shell script run before/after each connection (tilde-expanded). Receives `SUSSHI_*` environment variables. Non-zero exit from `pre_connect_hook` aborts the connection. Can also be set per-server.
+  - `hook_timeout_secs`: Maximum seconds to wait for a hook to exit before killing it (default: `5`).
 - **`groups`**: The top-level hierarchy. Can contain `environments` or direct `servers`.
   - Can override any default setting including `mode`.
 - **`environments`**: A sub-grouping under a Group.
@@ -281,6 +288,18 @@ susshi --direct myserver.com --user deploy --port 2222 --key ~/.ssh/deploy_rsa
 
 # Use a custom config file
 susshi --config ~/work/.susshi.yml
+
+# Import ~/.ssh/config
+susshi --import-ssh-config                        # print generated YAML to stdout
+susshi --import-ssh-config --dry-run              # preview, do not write
+susshi --import-ssh-config --output ~/.susshi.yml # write directly to a file
+susshi --import-ssh-config --ssh-config-path ~/work/.ssh/config  # alternate source
+
+# Export Ansible inventory
+susshi --export ansible                             # print to stdout
+susshi --export ansible --export-output ~/inventory.yml
+susshi --export ansible --export-filter "#prod"   # filter by tag
+susshi --export ansible --export-filter "web"     # filter by name
 
 # Show all options
 susshi --help

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -2,6 +2,50 @@
 # susshi - Example configuration
 # ==========================================
 
+# ─── VARIABLE TEMPLATING (optional) ────────────────────────────────────────
+# Define reusable scalar variables in an `_vars` top-level section and
+# reference them with {{ var_name }} in any string field of the same file
+# (host, user, ssh_key, name, …).
+#
+# Rules:
+#   - Scope is FILE-LOCAL — variables in an included file do not propagate to
+#     the parent file, and vice versa.
+#   - Only scalar string values are supported (no lists, no nested maps).
+#   - A reference to an undefined variable leaves the {{ placeholder }} intact
+#     and emits a non-blocking warning at startup.
+#
+# ── Built-in variable: {{ index }} ──────────────────────────────────────────
+# {{ index }} is a special variable automatically set to the 1-based position
+# of a server inside its parent list. It lets you declare a whole fleet of
+# similarly named servers as a compact block without copy-pasting:
+#
+# _vars:
+#   bastion: "bastion.prod.example.com"
+#   prod_key: "~/.ssh/prod_ed25519"
+#   subnet: "10.0.1"
+#
+# groups:
+#   - name: "Workers"
+#     environments:
+#       - name: "prod"
+#         defaults:
+#           jump:
+#             - host: "{{ bastion }}"
+#               user: "jump"
+#           ssh_key: "{{ prod_key }}"
+#           mode: jump
+#         servers:
+#           - name: "worker-{{ index }}"   # → worker-1, worker-2, worker-3 …
+#             host: "{{ subnet }}.{{ index }}"  # → 10.0.1.1, 10.0.1.2 …
+#           - name: "worker-{{ index }}"
+#             host: "{{ subnet }}.{{ index }}"
+#           - name: "worker-{{ index }}"
+#             host: "{{ subnet }}.{{ index }}"
+#   # Result: worker-1 @ 10.0.1.1, worker-2 @ 10.0.1.2, worker-3 @ 10.0.1.3
+#
+# Note: {{ index }} is resolved independently per list — if two environments
+# both contain servers using {{ index }}, each list starts at 1.
+
 # ─── MULTI-FILE (optional) ──────────────────────────────────────────────────
 # Split your configuration across multiple files by team or perimeter.
 # Each included file appears in the TUI as a collapsible namespace (📦).
@@ -33,6 +77,9 @@ defaults:
   theme: mocha
   # Set to true to reopen the TUI automatically after a connection closes
   keep_open: false
+  # Pre-apply a search filter when the TUI starts. The user can clear it with Esc.
+  # Supports the same syntax as the live search bar: text, #tag, or a mix.
+  # default_filter: "#prod"
   wallix:
     host: "bastion.example.com"
     user: "bastion"
@@ -115,6 +162,9 @@ groups:
             user: "root"
             host: "192.168.1.13"
             mode: "direct" # Standard SSH connection
+            # Tags are optional string labels used for filtering in the TUI (/)
+            # and in --export-filter. Support text + #tag syntax.
+            tags: [prod, eu-west, web]
           - name: "db-01"
             host: "192.168.1.11"
             # Appends /pg_data at server level: monitors /var/log, /data, /app_data AND /pg_data.

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -58,6 +58,30 @@ defaults:
     - "/var/log"
     - "/data"
 
+  # ─── SSH CONTROLMASTER (optional) ──────────────────────────────────────────
+  # Reuse SSH connections for the same host — subsequent connections are
+  # nearly instantaneous. Not supported in wallix mode.
+  # susshi automatically creates the parent directory of the socket path.
+  #
+  # control_master: true
+  # control_path: "~/.ssh/ctl/%h_%p_%r"   # default socket location
+  # control_persist: "10m"                # keep master alive 10 min after disconnect
+
+  # ─── HOOKS (optional) ──────────────────────────────────────────────────────
+  # Shell scripts executed before / after each SSH connection.
+  # Environment variables available inside the hook:
+  #   SUSSHI_SERVER  — server name as declared in the config
+  #   SUSSHI_HOST    — resolved hostname / IP
+  #   SUSSHI_USER    — SSH user
+  #   SUSSHI_PORT    — SSH port
+  #   SUSSHI_MODE    — connection mode (direct | jump | wallix)
+  # A non-zero exit code from pre_connect_hook cancels the connection.
+  # hook_timeout_secs prevents blocking on slow hooks (default: 5).
+  #
+  # pre_connect_hook: "~/.config/susshi/hooks/pre_connect.sh"
+  # post_disconnect_hook: "~/.config/susshi/hooks/post_disconnect.sh"
+  # hook_timeout_secs: 5
+
   # ─── SSH TUNNELS (optional) ───────────────────────────────────────────────
   # Pre-configured SSH local-port-forwarding tunnels for a server.
   # Press `T` in the TUI to open the tunnel manager and start/stop each tunnel.


### PR DESCRIPTION
## Documentation v0.11.0

Mise à jour de la documentation pour couvrir les nouvelles features de la v0.11.0.

### Contenu
- **CHANGELOG.md** — section `[Unreleased]` complète
- **README.md** — nouveaux bullets Features, CLI enrichi, Configuration Breakdown
- **examples/full_config.yaml** — blocs commentés pour `_vars`, `{{ index }}`, ControlMaster, hooks, tags, `default_filter`

### Features documentées
- Step 3 : Import `~/.ssh/config`
- Step 4 : Templating `_vars` + `{{ index }}`
- Step 5 : Tags + filtres avancés (`#tag`)
- Step 7 : ControlMaster SSH multiplexing
- Step 8 : Hooks `pre_connect` / `post_disconnect`
- Step 9 : Export inventaire Ansible
