### PR TITLE
fix(ci): release_always in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,6 +5,10 @@ git_release_enable = true
 git_release_body = "{{ changelog }}"
 # Do not publish to crates.io
 publish = false
+# Always create a release PR even when no file changes are detected
+# (needed for projects not published to crates.io — version bump is driven
+# solely by conventional commits since the last git tag)
+release_always = true
 
 [changelog]
 # Keep a Changelog-compatible format


### PR DESCRIPTION
Add \`release_always = true\` to force release-plz to create a release PR based on conventional commits, even when it cannot detect package file changes (expected behavior for non-published crates).