### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [0.11.0] — 2026-03-03
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Bump version to 0.11.0 and finalize CHANGELOG. Triggers release-plz to create tag v0.11.0 and GitHub Release.