### PR TITLE
fix: add Cargo.toml metadata for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 name = "susshi"
 version = "0.11.0"
 edition = "2024"
+description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
+license = "MIT"
+repository = "https://github.com/yatoub/susshi"
+homepage = "https://github.com/yatoub/susshi"
+documentation = "https://github.com/yatoub/susshi/blob/master/README.md"
+keywords = ["ssh", "tui", "terminal", "manager", "ratatui"]
+categories = ["command-line-utilities", "network-programming"]
+exclude = ["target/", ".idea/", ".github/"]
 
 [dependencies]
 anyhow = "1.0.102"


### PR DESCRIPTION
Add description, license, repository, keywords and categories required by crates.io.