### PR TITLE
fix(ci): install OpenSSL for x86_64-apple-darwin build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,12 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Install OpenSSL (macOS x86_64)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: |
+          brew install openssl@3
+          echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+
       - name: Build release
         shell: bash
         run: |


### PR DESCRIPTION
Le runner macOS x86_64 n'a pas OpenSSL dans le PATH. Installation via brew + OPENSSL_DIR.