### PR TITLE
fix(ci): use macos-13 (Intel) for x86_64-apple-darwin target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary_name: susshi
             asset_name: susshi-linux-amd64
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
             binary_name: susshi
             asset_name: susshi-macos-amd64


### PR DESCRIPTION
macos-latest est maintenant ARM (M1/M2). Cross-compilation x86_64 depuis ARM échoue au linkage. macos-13 est le dernier runner Intel natif.