### PR TITLE
fix(ci): use PAT for release-plz to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Run release-plz
         uses: release-plz/action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT is required here (not GITHUB_TOKEN) so that the tag pushed by
+          # release-plz triggers the release.yml workflow. GitHub does not fire
+          # workflow events for actions performed by the built-in GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
GitHub does not fire workflow events for pushes/tags performed by the built-in \`GITHUB_TOKEN\`. Switching to \`RELEASE_PLZ_TOKEN\` (fine-grained PAT with \`contents:write\` + \`pull-requests:write\`) ensures that tags created by release-plz correctly trigger \`release.yml\`.