### PR TITLE
fix(ci): fix macOS build compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary_name: susshi
             asset_name: susshi-linux-amd64
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: susshi
             asset_name: susshi-macos-amd64
@@ -75,6 +75,7 @@ jobs:
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
           brew install openssl@3
+          rustup target add x86_64-apple-darwin
           echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
 
       - name: Build release

--- a/src/ssh/sftp.rs
+++ b/src/ssh/sftp.rs
@@ -354,16 +354,16 @@ fn open_session_via_jump(jump_str: &str, server: &ResolvedServer) -> Result<ssh2
 
     // ── 3. Socketpair Unix : relie le bridge à la session cible sans TCP local ────
     let mut pair_fds: [libc::c_int; 2] = [-1; 2];
-    if unsafe {
-        libc::socketpair(
-            libc::AF_UNIX,
-            libc::SOCK_STREAM | libc::SOCK_CLOEXEC,
-            0,
-            pair_fds.as_mut_ptr(),
-        )
-    } != 0
+    // SOCK_CLOEXEC n'est pas défini par le crate libc sur macOS (libc ≤ 0.2.182).
+    // On l'applique via fcntl après creation pour garder la portabilité.
+    if unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, pair_fds.as_mut_ptr()) } != 0
     {
         anyhow::bail!("socketpair: {}", std::io::Error::last_os_error());
+    }
+    // Marquer les deux fds comme close-on-exec pour éviter toute fuite vers
+    // d'éventuels processus enfants (portabilité Linux + macOS).
+    for &fd in &pair_fds {
+        unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) };
     }
     // Safety : les deux fds sont valides, on en transfère l'ownership immédiatement.
     let local_stream = unsafe { UnixStream::from_raw_fd(pair_fds[0]) };


### PR DESCRIPTION
Fixes two failures in \`release.yml\` run 22617599878:

### 1. \`SOCK_CLOEXEC\` manquant sur macOS (\`aarch64-apple-darwin\`)
\`libc::SOCK_CLOEXEC\` n'est pas défini dans le crate \`libc\` 0.2 pour macOS (même si la constante C existe depuis macOS 10.8). Remplacement par un appel \`fcntl(F_SETFD, FD_CLOEXEC)\` après \`socketpair()\`, portable Linux + macOS.

### 2. Runner \`macos-13\` déprécié (\`x86_64-apple-darwin\`)
Le runner \`macos-13\` n'est plus supporté. Passage à \`macos-latest\` (ARM) avec \`rustup target add x86_64-apple-darwin\` pour la cross-compilation Intel.