### PR TITLE
fix(ci): fix x86_64 cross-compilation OpenSSL on ARM macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,16 @@ jobs:
       - name: Install OpenSSL (macOS x86_64)
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
-          brew install openssl@3
           rustup target add x86_64-apple-darwin
-          echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+          # On macos-latest (ARM/M-series), Homebrew lives in /opt/homebrew and only
+          # provides ARM binaries. For x86_64 cross-compilation we need a separate
+          # x86_64 Homebrew in /usr/local (Rosetta path).
+          arch -x86_64 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+            < /dev/null
+          arch -x86_64 /usr/local/bin/brew install openssl@3
+          echo "OPENSSL_DIR=/usr/local/opt/openssl@3" >> $GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $GITHUB_ENV
 
       - name: Build release
         shell: bash


### PR DESCRIPTION
## Problème

Sur \`macos-latest\` (Apple Silicon M-series), Homebrew est installé dans \`/opt/homebrew\` et ne fournit que des binaires ARM. La cross-compilation pour \`x86_64-apple-darwin\` échouait avec :

\`\`\`
ld: warning: ignoring file '/opt/homebrew/opt/openssl@3/lib/libssl.dylib': found architecture 'arm64', required architecture 'x86_64'
\`\`\`

## Fix

Instalation d'un Homebrew x86_64 séparé via Rosetta (\`arch -x86_64\`) dans \`/usr/local\` (chemin historique Intel), puis OpenSSL x86_64 depuis ce Homebrew. \`OPENSSL_STATIC=1\` évite le dynamic linking contre des bibliothèques ARM.