### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.13.0] — 2026-03-13
+
+### Added
+
+- Derive authorization candidates from YAML structure
+
+- Add diagnostic profile and manual TUI selector
+
+- Automate menu selection through a PTY session
+
+- Add menu parser and selection algorithm
+
+
+### Changed
+
+- Support inherited group in wallix config block
+
+- Add Wallix menu selection configuration schema
+
+
+### Fixed
+
+- Finalize anonymized fixtures and matching behavior
+
+- Support prefixed authorization groups and manual fallback
+
+- Scan paginated menu before failing selection
+
+- Auto-fill post-checkout target address prompt
+
+- Derive target aliases from fqdn and resolved structure
+
+
 ## [0.12.2] — 2026-03-10
 
 ### build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.12.2"
+version = "0.13.0"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.12.2 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `susshi` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Server.wallix_group in /tmp/.tmp3bKzaj/susshi/src/config.rs:297
  field BastionConfig.group in /tmp/.tmp3bKzaj/susshi/src/config.rs:218
  field BastionConfig.account in /tmp/.tmp3bKzaj/susshi/src/config.rs:221
  field BastionConfig.protocol in /tmp/.tmp3bKzaj/susshi/src/config.rs:223
  field BastionConfig.auto_select in /tmp/.tmp3bKzaj/susshi/src/config.rs:225
  field BastionConfig.fail_if_menu_match_error in /tmp/.tmp3bKzaj/susshi/src/config.rs:227
  field BastionConfig.selection_timeout_secs in /tmp/.tmp3bKzaj/susshi/src/config.rs:229
  field ProbeResult.profile in /tmp/.tmp3bKzaj/susshi/src/probe.rs:81
  field ProbeResult.notes in /tmp/.tmp3bKzaj/susshi/src/probe.rs:101
  field Environment.wallix_group in /tmp/.tmp3bKzaj/susshi/src/config.rs:279
  field ResolvedServer.wallix_group in /tmp/.tmp3bKzaj/susshi/src/config.rs:328
  field ResolvedServer.wallix_account in /tmp/.tmp3bKzaj/susshi/src/config.rs:330
  field ResolvedServer.wallix_protocol in /tmp/.tmp3bKzaj/susshi/src/config.rs:332
  field ResolvedServer.wallix_auto_select in /tmp/.tmp3bKzaj/susshi/src/config.rs:334
  field ResolvedServer.wallix_fail_if_menu_match_error in /tmp/.tmp3bKzaj/susshi/src/config.rs:336
  field ResolvedServer.wallix_selection_timeout_secs in /tmp/.tmp3bKzaj/susshi/src/config.rs:338
  field Group.wallix_group in /tmp/.tmp3bKzaj/susshi/src/config.rs:261
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0] — 2026-03-13

### Added

- Derive authorization candidates from YAML structure

- Add diagnostic profile and manual TUI selector

- Automate menu selection through a PTY session

- Add menu parser and selection algorithm


### Changed

- Support inherited group in wallix config block

- Add Wallix menu selection configuration schema


### Fixed

- Finalize anonymized fixtures and matching behavior

- Support prefixed authorization groups and manual fallback

- Scan paginated menu before failing selection

- Auto-fill post-checkout target address prompt

- Derive target aliases from fqdn and resolved structure
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).