### PR TITLE
chore: release v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.13.0 -> 0.13.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0] — 2026-03-13

### Added

- Derive authorization candidates from YAML structure

- Add diagnostic profile and manual TUI selector

- Automate menu selection through a PTY session

- Add menu parser and selection algorithm


### Changed

- Support inherited group in wallix config block

- Add Wallix menu selection configuration schema


### Fixed

- Finalize anonymized fixtures and matching behavior

- Support prefixed authorization groups and manual fallback

- Scan paginated menu before failing selection

- Auto-fill post-checkout target address prompt

- Derive target aliases from fqdn and resolved structure
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).