### PR TITLE
docs: add DEB and RPM installation instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,8 +68,10 @@ merge de la PR release-plz
   └── release-plz.yml : crée le tag vX.Y.Z + GitHub Release
 
 push tag v*.*.*
-  └── release.yml     : build Linux x86_64 / macOS Intel / macOS ARM / Windows x86_64
-                        → binaires attachés à la GitHub Release
+  └── release.yml     : build binaires (Linux/macOS/Windows)
+                        + paquets DEB (x86_64/arm64)
+                        + paquets RPM (x86_64)
+                        → tous attachés à la GitHub Release
 ```
 
 ### Workflows
@@ -78,5 +80,5 @@ push tag v*.*.*
 |---|---|---|
 | `ci.yml` | push `master` + PR | fmt, clippy, tests |
 | `release-plz.yml` | push `master` | PR de release + tag + GitHub Release |
-| `release.yml` | push tag `v*.*.*` | build multiplateforme + upload binaires |
+| `release.yml` | push tag `v*.*.*` | build binaires + paquets DEB/RPM + upload |
 | `aur-publish.yml` | push tag `v*.*.*` | mise à jour du PKGBUILD AUR |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,81 @@ jobs:
           asset_name: ${{ matrix.asset_name }}
           tag: ${{ github.event.inputs.tag || github.ref }}
           overwrite: true
+
+  build-deb:
+    name: Build DEB packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deb and cross
+        run: |
+          cargo install cargo-deb
+          cargo install cross
+
+      - name: Build amd64 DEB
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu
+          cargo deb --no-build --target x86_64-unknown-linux-gnu
+
+      - name: Build arm64 DEB (cross)
+        run: |
+          cross build --release --target aarch64-unknown-linux-gnu
+          cargo deb --no-build --target aarch64-unknown-linux-gnu
+
+      - name: Upload DEBs to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/debian/susshi_*.deb
+          file_glob: true
+          tag: ${{ github.event.inputs.tag || github.ref }}
+          overwrite: true
+
+  build-rpm:
+    name: Build RPM package
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install build dependencies
+        run: dnf install -y rust cargo openssl-devel rpm-build rpmdevtools git
+
+      - name: Setup rpmbuild tree
+        run: rpmdev-setuptree
+
+      - name: Patch version in spec
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          sed -i "s/^Version:.*/Version:        ${VERSION}/" susshi.spec
+
+      - name: Fetch source archive
+        run: spectool -g -R susshi.spec
+
+      - name: Build RPM
+        run: rpmbuild -ba susshi.spec
+
+      - name: Upload RPMs to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ~/rpmbuild/RPMS/**/*.rpm
+          file_glob: true
+          tag: ${{ github.event.inputs.tag || github.ref }}
+          overwrite: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,20 @@ lto = true
 codegen-units = 1
 # Pas de symboles de panic verbeux (remplace "panicked at …" par abort)
 panic = "abort"
+
+[package.metadata.deb]
+name = "susshi"
+maintainer = "yatoub <yatoub@users.noreply.github.com>"
+copyright = "2024-2026 yatoub"
+license-file = ["LICENCE", "0"]
+extended-description = """\
+susshi is a modern, terminal-based SSH connection manager \
+with TUI (ratatui + Catppuccin theme), multi-mode connections \
+(direct, jump, bastion/Wallix), and YAML configuration."""
+depends = "openssh-client"
+recommends = "xclip | xdotool"
+section = "net"
+priority = "optional"
+assets = [
+    ["target/release/susshi", "usr/bin/susshi", "755"],
+]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It helps you organize servers, handle complex access flows (jump hosts, Wallix b
     - [Advanced Features](#advanced-features)
   - [Installation](#installation)
     - [Pre-built binaries](#pre-built-binaries)
+    - [Ubuntu / Debian (x86_64, ARM64)](#ubuntu--debian-x86_64-arm64)
+    - [Fedora / RHEL (x86_64)](#fedora--rhel-x86_64)
     - [AUR (Arch Linux)](#aur-arch-linux)
     - [Build from source](#build-from-source)
   - [Configuration](#configuration)
@@ -108,6 +110,31 @@ wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-amd6
 
 # macOS Apple Silicon
 wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-arm64
+```
+
+### Ubuntu / Debian (x86_64, ARM64)
+
+Install from native DEB packages:
+
+```bash
+# x86_64
+sudo apt-get update && sudo apt-get install -y openssh-client xclip
+wget https://github.com/yatoub/susshi/releases/latest/download/susshi_*_amd64.deb
+sudo dpkg -i susshi_*_amd64.deb
+
+# ARM64
+wget https://github.com/yatoub/susshi/releases/latest/download/susshi_*_arm64.deb
+sudo dpkg -i susshi_*_arm64.deb
+```
+
+### Fedora / RHEL (x86_64)
+
+Install from native RPM packages:
+
+```bash
+sudo dnf install openssh-clients
+wget https://github.com/yatoub/susshi/releases/latest/download/susshi-*.x86_64.rpm
+sudo dnf install ./susshi-*.x86_64.rpm
 ```
 
 ### AUR (Arch Linux)

--- a/susshi.spec
+++ b/susshi.spec
@@ -1,0 +1,39 @@
+Name:           susshi
+Version:        0.14.0
+Release:        1%{?dist}
+Summary:        Modern terminal-based SSH connection manager
+License:        MIT
+URL:            https://github.com/yatoub/susshi
+Source0:        https://github.com/yatoub/susshi/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  cargo
+BuildRequires:  openssl-devel
+Requires:       openssh-clients
+
+%description
+susshi is a modern TUI SSH connection manager with Catppuccin theme,
+supporting direct, jump, and Wallix bastion connections.
+
+%prep
+%autosetup -n %{name}-%{version}
+export RUSTUP_TOOLCHAIN=stable
+cargo fetch --locked
+
+%build
+export RUSTUP_TOOLCHAIN=stable
+cargo build --frozen --release
+
+%check
+export RUSTUP_TOOLCHAIN=stable
+cargo test --frozen
+
+%install
+install -Dm0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENCE
+%{_bindir}/%{name}
+
+%changelog
+* Wed Mar 17 2026 yatoub <yatoub@users.noreply.github.com> - 0.14.0-1
+- Initial RPM packaging for susshi


### PR DESCRIPTION
Closes #<issue-number> (v0.14.0 Roadmap - Packaging)

## Overview
Implement native DEB and RPM packaging support for easier distribution on Ubuntu/Debian and Fedora/RHEL systems.

## What's included
- **Epic 1 — cargo-deb**: Added metadata to `Cargo.toml` with support for x86_64 and ARM64 DEB packages
- **Epic 2 — susshi.spec**: Created for Fedora/RHEL RPM packaging with full build instructions
- **Epic 3 — CI/CD Integration**: 
  - Added `build-deb` job to `release.yml` (generates x86_64 + ARM64 packages via cargo-deb and cross)
  - Added `build-rpm` job to `release.yml` (generates x86_64 RPM via rpmbuild in Fedora container)
- **Epic 5 — Documentation**: Updated README with DEB and RPM installation instructions

## Artifacts after release
Each GitHub Release will include:
- Binary artifacts (Linux, macOS, Windows — unchanged)
- **susshi_<version>_amd64.deb** (Debian/Ubuntu x86_64)
- **susshi_<version>_arm64.deb** (Debian/Ubuntu ARM64)
- **susshi-<version>-1.fc*.x86_64.rpm** (Fedora/RHEL x86_64)

## Testing
- ✅ `cargo fmt --check`  
- ✅ `cargo clippy -- -D warnings`
- ✅ `cargo test` (all tests passing)