### PR TITLE
fix(ci): use vendored OpenSSL for arm64 DEB cross build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.2+3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1176,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 shellexpand = "3.1.2"
-ssh2 = "0.9"
+ssh2 = { version = "0.9", features = ["vendored-openssl"] }
 thiserror = "2.0.18"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
## Why
The DEB packaging workflow fails on ARM64 cross-build because openssl-sys cannot find target OpenSSL pkg-config metadata (openssl.pc).

## What
- Enable vendored OpenSSL via ssh2 feature flag in Cargo.toml
- Commit generated lockfile update

## Validation
- cargo check
- cargo clippy -- -D warnings
- cargo test

This PR contains only the CI/build reliability fix after merge of #45.