### PR TITLE
chore: release v0.13.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.13.4 -> 0.13.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).