### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.14.0] — 2026-03-25
+
+### Added
+
+- Externalize remaining tui labels for wallix and scp
+
+- Implement deterministic auth flow and targeted fallback
+
+
 ## [0.13.6] — 2026-03-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.13.6"
+version = "0.14.0"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.13.6 -> 0.14.0 (⚠ API breaking changes)

### ⚠ `susshi` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Strings.details_namespace in /tmp/.tmpWczr1J/susshi/src/i18n.rs:67
  field Strings.details_group in /tmp/.tmpWczr1J/susshi/src/i18n.rs:69
  field Strings.details_environment in /tmp/.tmpWczr1J/susshi/src/i18n.rs:71
  field Strings.hint_navigate in /tmp/.tmpWczr1J/susshi/src/i18n.rs:110
  field Strings.hint_validate_cancel in /tmp/.tmpWczr1J/susshi/src/i18n.rs:111
  field Strings.hint_clear in /tmp/.tmpWczr1J/susshi/src/i18n.rs:112
  field Strings.hint_connect in /tmp/.tmpWczr1J/susshi/src/i18n.rs:113
  field Strings.hint_clear_filter in /tmp/.tmpWczr1J/susshi/src/i18n.rs:114
  field Strings.hint_new_search in /tmp/.tmpWczr1J/susshi/src/i18n.rs:115
  field Strings.hint_quit in /tmp/.tmpWczr1J/susshi/src/i18n.rs:116
  field Strings.hint_expand in /tmp/.tmpWczr1J/susshi/src/i18n.rs:117
  field Strings.hint_search in /tmp/.tmpWczr1J/susshi/src/i18n.rs:118
  field Strings.hint_mode in /tmp/.tmpWczr1J/susshi/src/i18n.rs:119
  field Strings.hint_tunnels in /tmp/.tmpWczr1J/susshi/src/i18n.rs:120
  field Strings.hint_probe in /tmp/.tmpWczr1J/susshi/src/i18n.rs:121
  field Strings.hint_command in /tmp/.tmpWczr1J/susshi/src/i18n.rs:122
  field Strings.hint_scp in /tmp/.tmpWczr1J/susshi/src/i18n.rs:123
  field Strings.hint_copy_ssh in /tmp/.tmpWczr1J/susshi/src/i18n.rs:124
  field Strings.hint_favorite in /tmp/.tmpWczr1J/susshi/src/i18n.rs:125
  field Strings.hint_favorites_view in /tmp/.tmpWczr1J/susshi/src/i18n.rs:126
  field Strings.hint_reload in /tmp/.tmpWczr1J/susshi/src/i18n.rs:127
  field Strings.hint_recent_sort in /tmp/.tmpWczr1J/susshi/src/i18n.rs:128
  field Strings.hint_collapse in /tmp/.tmpWczr1J/susshi/src/i18n.rs:129
  field Strings.hint_verbose in /tmp/.tmpWczr1J/susshi/src/i18n.rs:130
  field Strings.wallix_selector_title in /tmp/.tmpWczr1J/susshi/src/i18n.rs:133
  field Strings.wallix_selector_loading in /tmp/.tmpWczr1J/susshi/src/i18n.rs:135
  field Strings.wallix_selector_loading_hint in /tmp/.tmpWczr1J/susshi/src/i18n.rs:136
  field Strings.wallix_selector_cancel_hint in /tmp/.tmpWczr1J/susshi/src/i18n.rs:137
  field Strings.wallix_selector_error in /tmp/.tmpWczr1J/susshi/src/i18n.rs:139
  field Strings.wallix_selector_close_hint in /tmp/.tmpWczr1J/susshi/src/i18n.rs:140
  field Strings.wallix_selector_choose in /tmp/.tmpWczr1J/susshi/src/i18n.rs:142
  field Strings.wallix_selector_list_hint in /tmp/.tmpWczr1J/susshi/src/i18n.rs:143
  field Strings.scp_direction_upload_label in /tmp/.tmpWczr1J/susshi/src/i18n.rs:243
  field Strings.scp_direction_download_label in /tmp/.tmpWczr1J/susshi/src/i18n.rs:245
  field Strings.scp_form_title in /tmp/.tmpWczr1J/susshi/src/i18n.rs:250
  field Strings.scp_eta_label in /tmp/.tmpWczr1J/susshi/src/i18n.rs:264
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0] — 2026-03-25

### Added

- Externalize remaining tui labels for wallix and scp

- Implement deterministic auth flow and targeted fallback
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).