### PR TITLE
feat: SSH credential prompt (passphrase / password) in TUI

### DIFF
--- a/i18n/en/susshi.ftl
+++ b/i18n/en/susshi.ftl
@@ -1,0 +1,209 @@
+# ── Error dialog ─────────────────────────────────────────────────────────────
+error-title = ⚠  Error
+error-dismiss = Press Enter or Esc to close
+
+# ── Connection tabs ───────────────────────────────────────────────────────────
+tab-title = Connection Mode (Tab to switch)
+tab-direct = Direct [1]
+tab-jump = Jump [2]
+tab-wallix = Wallix [3]
+
+# ── Verbose toggle ────────────────────────────────────────────────────────────
+verbose-title = Options (v to toggle)
+verbose-label = Verbose (-v)
+
+# ── Search bar ────────────────────────────────────────────────────────────────
+search-idle-hint = Press / to search...
+search-title-idle = Search (press /)
+search-placeholder = (search by name or host, ESC to cancel)
+search-title-active = 🔍 Search by name/host ({ $total } servers)
+search-no-results = 🔍 No results for '{ $query }'
+search-all-match = 🔍 All { $count } servers match
+search-partial = 🔍 { $found } / { $total } servers
+search-result-all = ✓ Showing all { $count } servers
+search-result-partial = ✓ { $found } / { $total } servers match '{ $query }'
+
+# ── Main panels ───────────────────────────────────────────────────────────────
+panel-servers = Servers
+panel-details = Details
+details-placeholder = Select a server to view details.
+details-namespace = 📦 Namespace: { $label }
+details-group = Group: { $name }
+details-environment = Environment: { $group } / { $env }
+
+# ── Details panel labels ──────────────────────────────────────────────────────
+label-name = Name:
+label-host = Host:
+label-port = Port:
+label-user = User:
+label-mode = Mode:
+label-key = Key:
+label-jump = Jump:
+label-wallix = Wallix:
+label-options = Options:
+
+# ── Probe / diagnostics ───────────────────────────────────────────────────────
+probe-section = ─── System ──────────────────────
+probe-hint =   d — probe
+probe-running = Running probe…
+probe-kernel = Kernel
+probe-cpu = CPU
+probe-cpu-cores = Cores
+probe-os = OS
+probe-load = Load
+probe-ram = RAM
+probe-disk = Disk /
+probe-wallix-error = Probe unavailable in Wallix mode
+probe-disk-extra = Disk { $mount }
+probe-fs-absent = ⚠  { $mount } — not mounted
+
+# ── Status bar ────────────────────────────────────────────────────────────────
+status-normal = Navigate: ↑/↓ | Expand: Space/Enter | Search: / | Mode: Tab/1-3 | v: Verbose | y: Copy | d: Probe | f: Fav | F: Favs | r: Reload | x: Cmd | H: Sort | C: Collapse all | q: Quit
+status-searching = Search Mode: Type to filter | ESC: Cancel | Ctrl+U: Clear | Enter: Apply
+status-search-active = Navigate: ↑/↓ | Clear: ESC | New search: / | Verbose: v | Enter: Connect | q: Quit
+
+# ── Keyboard hints ────────────────────────────────────────────────────────────
+hint-navigate = navigate
+hint-validate-cancel = apply / cancel
+hint-clear = clear
+hint-connect = connect
+hint-clear-filter = clear filter
+hint-new-search = new search
+hint-quit = quit
+hint-expand = expand
+hint-search = search
+hint-mode = mode
+hint-tunnels = tunnels
+hint-probe = probe
+hint-command = command
+hint-scp = SCP
+hint-copy-ssh = copy SSH
+hint-favorite = favorite
+hint-favorites-view = ★ favorites view
+hint-reload = reload
+hint-recent-sort = recent sort
+hint-collapse = collapse
+hint-verbose = verbose
+
+# ── Wallix selector overlay ───────────────────────────────────────────────────
+wallix-selector-title = Wallix Selection
+wallix-selector-loading = Loading Wallix entries for { $server }…
+wallix-selector-loading-hint = Contacting the bastion and reading the interactive menu.
+wallix-selector-cancel-hint = Esc/q: cancel
+wallix-selector-error = Wallix selector error for { $server }
+wallix-selector-close-hint = Enter/Esc/q: close
+wallix-selector-choose = Select the Wallix entry for { $server } ({ $host })
+wallix-selector-list-hint = ↑/↓: navigate | Enter: connect | Esc/q: cancel
+
+# ── Include warnings ──────────────────────────────────────────────────────────
+include-warn-load = Failed to load '{ $label }' ({ $path }) : { $error }
+include-warn-circular = Circular dependency ignored: '{ $label }' ({ $path })
+include-warn-nested = Nested includes in '{ $label }' are ignored (v0.7)
+
+# ── Status messages ───────────────────────────────────────────────────────────
+copied = Copied: { $cmd }
+clipboard-error = Clipboard error: { $error }
+clipboard-unavailable = Clipboard unavailable
+ssh-error = SSH error: { $error }
+
+# ── Connection history ────────────────────────────────────────────────────────
+last-seen-label = Last conn.:
+last-seen-never = —
+last-seen-ago = { $duration } ago
+last-seen-just-now = just now
+
+# ── Hot reload ────────────────────────────────────────────────────────────────
+config-reloaded = Config reloaded ({ $count } servers)
+config-reload-error = Config reload error
+
+# ── Favorites ────────────────────────────────────────────────────────────────
+favorites-title = ⭐ Favorites
+favorite-added = ⭐ Added to favorites
+favorite-removed = Removed from favorites
+
+# ── Sort by recency ───────────────────────────────────────────────────────────
+sort-recent-on = Sort: recent [H]
+sort-recent-off = Sort: alpha  [H]
+
+# ── Ad-hoc command ────────────────────────────────────────────────────────────
+cmd-prompt = Command:
+cmd-running = Running…
+cmd-exit-err = Error (exit { $code })
+
+# ── YAML validation ───────────────────────────────────────────────────────────
+validation-title = ⚠  Configuration warnings
+validation-unknown-field = { $file } ({ $context }): unknown field "{ $field }"
+
+# ── SSH tunnels ───────────────────────────────────────────────────────────────
+tunnel-wallix-unavailable = SSH tunnels unavailable in Wallix mode
+tunnel-not-found = Tunnel #{ $index } not found for this server
+tunnel-already-active = Tunnel '{ $label }' already active (port { $port })
+tunnel-started = Tunnel '{ $label }' started on port { $port }
+tunnel-error = Tunnel error: { $error }
+tunnel-stopped = Tunnel '{ $label }' (port { $port }) stopped
+tunnel-died = Tunnel '{ $label }' (port { $port }) died: { $reason }
+tunnel-deleted = Tunnel deleted
+tunnel-updated = Tunnel updated
+tunnel-added = Tunnel added
+tunnel-overlay-new = + (new tunnel)
+tunnel-overlay-hints1 =   ↑↓ navigate   Enter start/stop   Del delete
+tunnel-overlay-hints2 =   e edit        a add              q/Esc close
+tunnel-form-edit-title = Edit tunnel — { $server }
+tunnel-form-new-title = New tunnel — { $server }
+tunnel-form-field-label =   Label       :
+tunnel-form-field-local-port =   Local port  :
+tunnel-form-field-remote-host =   Remote host :
+tunnel-form-field-remote-port =   Remote port :
+tunnel-form-hint =   Tab next field   Enter validate   Esc cancel
+tunnel-form-local-port-invalid = Invalid local port (1–65535 expected)
+tunnel-form-remote-host-empty = Remote host required
+tunnel-form-remote-port-invalid = Invalid remote port (1–65535 expected)
+tunnel-badge-label = Tunnels:
+tunnel-badge-active =
+    { $n_run ->
+        [one]  { $n_run } active / { $n_cfg ->
+            [one]  { $n_cfg } configured
+           *[other] { $n_cfg } configured
+        }
+       *[other] { $n_run } active / { $n_cfg ->
+            [one]  { $n_cfg } configured
+           *[other] { $n_cfg } configured
+        }
+    }
+tunnel-badge-none =
+    { $n_cfg ->
+        [one]  { $n_cfg } configured, none active
+       *[other] { $n_cfg } configured, none active
+    }
+
+# ── SCP ───────────────────────────────────────────────────────────────────────
+scp-wallix-unavailable = SCP unavailable in Wallix mode
+scp-done-ok = SCP complete ✔
+scp-done-err = SCP completed with errors ✗
+scp-failed = SCP failed: { $error }
+scp-form-local-required = Local path required
+scp-form-remote-required = Remote path required
+scp-direction-title = SCP Transfer — { $server }
+scp-direction-upload-label = Upload
+scp-direction-download-label = Download
+scp-direction-upload = (local → server)
+scp-direction-download = (server → local)
+scp-direction-hint =   Esc cancel
+scp-form-title = SCP { $direction } — { $server }
+scp-form-field-local =   Local  :
+scp-form-field-remote =   Remote :
+scp-form-hint =   Tab switch field   Enter confirm   Esc cancel
+scp-result-title = SCP Result
+scp-result-success = SCP { $direction } completed successfully
+scp-result-errors = SCP { $direction } completed with errors
+scp-result-fail = SCP error: { $error }
+scp-result-hint =   Enter / Esc  close
+scp-in-progress = SCP { $direction } in progress...
+scp-eta-label = ETA
+
+# ── Credential input dialog ───────────────────────────────────────────────────
+credential-input-title-passphrase = SSH Key Passphrase — { $server }
+credential-input-title-password = SSH Password — { $server }
+credential-input-prompt-passphrase =   Passphrase :
+credential-input-prompt-password =   Password   :
+credential-input-hint =   Enter confirm   Esc cancel

--- a/i18n/fr/susshi.ftl
+++ b/i18n/fr/susshi.ftl
@@ -1,0 +1,209 @@
+# ── Fenêtre erreur ───────────────────────────────────────────────────────────
+error-title = ⚠  Erreur
+error-dismiss = Appuyez sur Entrée ou Esc pour fermer
+
+# ── Onglets connexion ─────────────────────────────────────────────────────────
+tab-title = Mode de Connexion (Tab pour changer)
+tab-direct = Direct [1]
+tab-jump = Rebond [2]
+tab-wallix = Wallix [3]
+
+# ── Toggle verbose ────────────────────────────────────────────────────────────
+verbose-title = Options (v pour basculer)
+verbose-label = Verbose (-v)
+
+# ── Barre de recherche ────────────────────────────────────────────────────────
+search-idle-hint = Appuyez sur / pour rechercher…
+search-title-idle = Recherche (/)
+search-placeholder = (nom ou hôte, Échap pour annuler)
+search-title-active = 🔍 Recherche nom/hôte ({ $total } serveurs)
+search-no-results = 🔍 Aucun résultat pour '{ $query }'
+search-all-match = 🔍 { $count } serveurs correspondent
+search-partial = 🔍 { $found } / { $total } serveurs
+search-result-all = ✓ { $count } serveurs affichés
+search-result-partial = ✓ { $found } / { $total } correspondent à '{ $query }'
+
+# ── Panneaux principaux ───────────────────────────────────────────────────────
+panel-servers = Serveurs
+panel-details = Détails
+details-placeholder = Sélectionnez un serveur pour voir les détails.
+details-namespace = 📦 Namespace : { $label }
+details-group = Group: { $name }
+details-environment = Environment: { $group } / { $env }
+
+# ── Libellés du panneau détails ───────────────────────────────────────────────
+label-name = Nom:
+label-host = Hôte:
+label-port = Port:
+label-user = Util.:
+label-mode = Mode:
+label-key = Clé:
+label-jump = Rebond:
+label-wallix = Wallix:
+label-options = Options:
+
+# ── Bloc diagnostic ───────────────────────────────────────────────────────────
+probe-section = ─── Système ─────────────────────
+probe-hint =   d — diagnostiquer
+probe-running = Diagnostic en cours…
+probe-kernel = Kernel
+probe-cpu = CPU
+probe-cpu-cores = Cœurs
+probe-os = OS
+probe-load = Charge
+probe-ram = RAM
+probe-disk = Disk /
+probe-wallix-error = Diagnostic non disponible en mode Wallix
+probe-disk-extra = Disk { $mount }
+probe-fs-absent = ⚠  { $mount } — non monté
+
+# ── Barre de statut ───────────────────────────────────────────────────────────
+status-normal = Navigation : ↑/↓ | Ouvrir : Espace/Entrée | Recherche : / | Mode : Tab/1-3 | v : Verbose | y : Copier | d : Probe | f : Favori | F : Vue favs | r : Recharger | x : Cmd | H : Tri | C : Replier tout | q : Quitter
+status-searching = Recherche : Tapez pour filtrer… | Échap : Annuler | Ctrl+U : Effacer | Entrée : Valider
+status-search-active = Navigation : ↑/↓ | Effacer : Échap | Nouvelle recherche : / | Verbose : v | Entrée : Connecter | q : Quitter
+
+# ── Aides clavier ─────────────────────────────────────────────────────────────
+hint-navigate = naviguer
+hint-validate-cancel = valider / annuler
+hint-clear = effacer
+hint-connect = connexion
+hint-clear-filter = effacer filtre
+hint-new-search = nouvelle recherche
+hint-quit = quitter
+hint-expand = expand
+hint-search = recherche
+hint-mode = mode
+hint-tunnels = tunnels
+hint-probe = probe
+hint-command = commande
+hint-scp = SCP
+hint-copy-ssh = copier SSH
+hint-favorite = favori
+hint-favorites-view = ★ vue favoris
+hint-reload = recharger
+hint-recent-sort = tri récent
+hint-collapse = replier
+hint-verbose = verbose
+
+# ── Overlay sélecteur Wallix ──────────────────────────────────────────────────
+wallix-selector-title = Sélection Wallix
+wallix-selector-loading = Chargement des entrées Wallix pour { $server }…
+wallix-selector-loading-hint = Connexion au bastion et lecture du menu interactif.
+wallix-selector-cancel-hint = Esc/q : annuler
+wallix-selector-error = Erreur du sélecteur Wallix pour { $server }
+wallix-selector-close-hint = Entrée/Esc/q : fermer
+wallix-selector-choose = Sélectionne l'entrée Wallix pour { $server } ({ $host })
+wallix-selector-list-hint = ↑/↓ : naviguer | Entrée : connecter | Esc/q : annuler
+
+# ── Avertissements includes ───────────────────────────────────────────────────
+include-warn-load = Impossible de charger '{ $label }' ({ $path }) : { $error }
+include-warn-circular = Dépendance circulaire ignorée : '{ $label }' ({ $path })
+include-warn-nested = Les includes imbriqués dans '{ $label }' sont ignorés (v0.7)
+
+# ── Messages de statut ────────────────────────────────────────────────────────
+copied = Copié : { $cmd }
+clipboard-error = Erreur presse-papiers : { $error }
+clipboard-unavailable = Presse-papiers indisponible
+ssh-error = Erreur SSH : { $error }
+
+# ── Historique des connexions ─────────────────────────────────────────────────
+last-seen-label = Dern. conn.:
+last-seen-never = —
+last-seen-ago = il y a { $duration }
+last-seen-just-now = à l'instant
+
+# ── Rechargement à chaud ──────────────────────────────────────────────────────
+config-reloaded = Config rechargée ({ $count } serveurs)
+config-reload-error = Erreur rechargement config
+
+# ── Favoris ───────────────────────────────────────────────────────────────────
+favorites-title = ⭐ Favoris
+favorite-added = ⭐ Ajouté aux favoris
+favorite-removed = Favori retiré
+
+# ── Sort par récence ──────────────────────────────────────────────────────────
+sort-recent-on = Tri : récent  [H]
+sort-recent-off = Tri : alpha   [H]
+
+# ── Commande ad-hoc ───────────────────────────────────────────────────────────
+cmd-prompt = Commande :
+cmd-running = Exécution…
+cmd-exit-err = Erreur (exit { $code })
+
+# ── Validation YAML ───────────────────────────────────────────────────────────
+validation-title = ⚠  Avertissements de configuration
+validation-unknown-field = { $file } ({ $context }): champ inconnu « { $field } »
+
+# ── Tunnels SSH ───────────────────────────────────────────────────────────────
+tunnel-wallix-unavailable = Tunnels SSH non disponibles en mode Wallix
+tunnel-not-found = Tunnel #{ $index } introuvable pour ce serveur
+tunnel-already-active = Tunnel « { $label } » déjà actif (port { $port })
+tunnel-started = Tunnel « { $label } » démarré sur le port { $port }
+tunnel-error = Erreur tunnel : { $error }
+tunnel-stopped = Tunnel « { $label } » (port { $port }) arrêté
+tunnel-died = Tunnel « { $label } » (port { $port }) s'est arrêté : { $reason }
+tunnel-deleted = Tunnel supprimé
+tunnel-updated = Tunnel mis à jour
+tunnel-added = Tunnel ajouté
+tunnel-overlay-new = + (nouveau tunnel)
+tunnel-overlay-hints1 =   ↑↓ naviguer   Enter démarrer/arrêter   Del supprimer
+tunnel-overlay-hints2 =   e éditer      a ajouter                q/Esc fermer
+tunnel-form-edit-title = Modifier le tunnel — { $server }
+tunnel-form-new-title = Nouveau tunnel — { $server }
+tunnel-form-field-label =   Label        :
+tunnel-form-field-local-port =   Port local   :
+tunnel-form-field-remote-host =   Hôte distant :
+tunnel-form-field-remote-port =   Port distant :
+tunnel-form-hint =   Tab champ suivant   Enter valider   Esc annuler
+tunnel-form-local-port-invalid = Port local invalide (entier 1–65535 attendu)
+tunnel-form-remote-host-empty = Hôte distant obligatoire
+tunnel-form-remote-port-invalid = Port distant invalide (entier 1–65535 attendu)
+tunnel-badge-label = Tunnels :
+tunnel-badge-active =
+    { $n_run ->
+        [one]   { $n_run } actif / { $n_cfg ->
+            [one]  { $n_cfg } configuré
+           *[other] { $n_cfg } configurés
+        }
+       *[other] { $n_run } actifs / { $n_cfg ->
+            [one]  { $n_cfg } configuré
+           *[other] { $n_cfg } configurés
+        }
+    }
+tunnel-badge-none =
+    { $n_cfg ->
+        [one]  { $n_cfg } configuré, aucun actif
+       *[other] { $n_cfg } configurés, aucun actif
+    }
+
+# ── SCP ───────────────────────────────────────────────────────────────────────
+scp-wallix-unavailable = SCP non disponible en mode Wallix
+scp-done-ok = SCP terminé ✔
+scp-done-err = SCP terminé avec des erreurs ✗
+scp-failed = SCP échoué : { $error }
+scp-form-local-required = Le chemin local est obligatoire
+scp-form-remote-required = Le chemin distant est obligatoire
+scp-direction-title = Transfert SCP — { $server }
+scp-direction-upload-label = Envoi
+scp-direction-download-label = Téléchargement
+scp-direction-upload = (local → serveur)
+scp-direction-download = (serveur → local)
+scp-direction-hint =   Esc annuler
+scp-form-title = SCP { $direction } — { $server }
+scp-form-field-local =   Local   :
+scp-form-field-remote =   Distant :
+scp-form-hint =   Tab changer de champ   Enter confirmer   Esc annuler
+scp-result-title = Résultat SCP
+scp-result-success = SCP { $direction } terminé avec succès
+scp-result-errors = SCP { $direction } terminé avec des erreurs
+scp-result-fail = Erreur SCP : { $error }
+scp-result-hint =   Enter / Esc  fermer
+scp-in-progress = SCP { $direction } en cours...
+scp-eta-label = Restant
+
+# ── Saisie de credential ──────────────────────────────────────────────────────
+credential-input-title-passphrase = Passphrase clé SSH — { $server }
+credential-input-title-password = Mot de passe SSH — { $server }
+credential-input-prompt-passphrase =   Passphrase :
+credential-input-prompt-password =   Mot de passe :
+credential-input-hint =   Enter confirmer   Esc annuler

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use crate::config::{
     Config, ConfigEntry, ConfigError, ConnectionMode, IncludeWarning, ResolvedServer, ThemeVariant,
     TunnelConfig, ValidationWarning,
 };
+use crate::fl;
 use crate::probe::{ProbeResult, ProbeState};
 use crate::ssh::sftp::{self as ssh_sftp, ScpDirection, ScpEvent};
 use crate::ssh::tunnel::{self as ssh_tunnel, TunnelHandle, TunnelStatus};
@@ -49,12 +50,27 @@ mod expansion_state;
 mod core_state;
 
 /// Mode courant de l'application.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default)]
 pub enum AppMode {
     #[default]
     Normal,
     /// Affiche un panneau d'erreur bloquant jusqu'à la confirmation.
     Error(String),
+    /// Saisie d'un credential SSH (passphrase de clé ou mot de passe) avant connexion.
+    CredentialInput {
+        server: Box<ResolvedServer>,
+        mode: ConnectionMode,
+        verbose: bool,
+        /// `true` = passphrase de clé, `false` = mot de passe
+        is_passphrase: bool,
+        input: String,
+    },
+}
+
+impl PartialEq for AppMode {
+    fn eq(&self, other: &Self) -> bool {
+        matches!((self, other), (Self::Normal, Self::Normal) | (Self::Error(_), Self::Error(_)))
+    }
 }
 
 /// État d'une commande SSH ad-hoc (touche `x`).
@@ -161,17 +177,17 @@ impl TunnelForm {
     }
 
     /// Valide les champs et retourne un `TunnelConfig` ou un message d'erreur.
-    pub fn validate(&self, lang: &crate::i18n::Strings) -> Result<TunnelConfig, String> {
+    pub fn validate(&self) -> Result<TunnelConfig, String> {
         let local_port = self
             .local_port
             .trim()
             .parse::<u16>()
             .ok()
             .filter(|&p| p >= 1)
-            .ok_or_else(|| lang.tunnel_form_local_port_invalid.to_string())?;
+            .ok_or_else(|| fl!("tunnel-form-local-port-invalid"))?;
 
         if self.remote_host.trim().is_empty() {
-            return Err(lang.tunnel_form_remote_host_empty.to_string());
+            return Err(fl!("tunnel-form-remote-host-empty"));
         }
 
         let remote_port = self
@@ -180,7 +196,7 @@ impl TunnelForm {
             .parse::<u16>()
             .ok()
             .filter(|&p| p >= 1)
-            .ok_or_else(|| lang.tunnel_form_remote_port_invalid.to_string())?;
+            .ok_or_else(|| fl!("tunnel-form-remote-port-invalid"))?;
 
         Ok(TunnelConfig {
             local_port,
@@ -207,7 +223,10 @@ pub enum TunnelOverlayState {
 #[derive(Debug, Clone)]
 pub enum WallixSelectorState {
     /// Récupération des entrées depuis le bastion.
-    Loading { server: Box<ResolvedServer> },
+    Loading {
+        server: Box<ResolvedServer>,
+        verbose: bool,
+    },
     /// Liste des entrées Wallix disponibles.
     List {
         server: Box<ResolvedServer>,
@@ -331,9 +350,6 @@ pub struct App {
     /// Récepteur du thread de diagnostic (présent seulement quand Running).
     pub probe_rx: Option<mpsc::Receiver<Result<ProbeResult, String>>>,
 
-    /// Jeu de chaînes localisées détecté au démarrage.
-    pub lang: &'static crate::i18n::Strings,
-
     /// Chemin du fichier de configuration principal (pour le rechargement).
     pub config_path: PathBuf,
 
@@ -389,6 +405,9 @@ pub struct App {
     pub wallix_selection_cache: HashMap<String, String>,
     /// Connexion Wallix prête à démarrer (résolue automatiquement ou via choix utilisateur).
     wallix_pending_connection: Option<(ResolvedServer, String)>,
+    /// Credential SSH temporaire (passphrase ou mot de passe) à utiliser pour la prochaine
+    /// connexion Wallix. Effacé après usage dans `take_pending_wallix_connection`.
+    pub wallix_pending_auth: Option<String>,
 }
 
 type WallixMenuLoadResult = (ResolvedServer, Result<Vec<WallixMenuEntry>, String>);
@@ -408,6 +427,10 @@ mod tests_search;
 #[cfg(test)]
 #[path = "app/tests_visibility.rs"]
 mod tests_visibility;
+
+#[cfg(test)]
+#[path = "app/tests_credential_input.rs"]
+mod tests_credential_input;
 
 #[cfg(test)]
 #[path = "app/tests_reload.rs"]

--- a/src/app/core_state.rs
+++ b/src/app/core_state.rs
@@ -27,6 +27,64 @@ impl App {
         self.app_mode = AppMode::Normal;
     }
 
+    /// Ouvre le dialog de saisie de credential SSH (passphrase ou mot de passe)
+    /// pour le serveur et le mode de connexion actuellement sélectionnés.
+    pub fn open_credential_input(&mut self, is_passphrase: bool) {
+        if let Some(server) = self.selected_server() {
+            self.app_mode = AppMode::CredentialInput {
+                server: Box::new(server.clone()),
+                mode: self.connection_mode,
+                verbose: self.verbose_mode,
+                is_passphrase,
+                input: String::new(),
+            };
+        }
+    }
+
+    /// Ajoute un caractère au buffer du credential en cours de saisie.
+    pub fn credential_input_push(&mut self, c: char) {
+        if let AppMode::CredentialInput { input, .. } = &mut self.app_mode {
+            input.push(c);
+        }
+    }
+
+    /// Supprime le dernier caractère du buffer de saisie.
+    pub fn credential_input_backspace(&mut self) {
+        if let AppMode::CredentialInput { input, .. } = &mut self.app_mode {
+            input.pop();
+        }
+    }
+
+    /// Annule la saisie et revient en mode Normal.
+    pub fn cancel_credential_input(&mut self) {
+        self.app_mode = AppMode::Normal;
+    }
+
+    /// Valide la saisie et retourne `(server, mode, verbose, credential)` si le buffer
+    /// n'est pas vide. Laisse le mode inchangé si le buffer est vide.
+    pub fn submit_credential_input(
+        &mut self,
+    ) -> Option<(ResolvedServer, crate::config::ConnectionMode, bool, String)> {
+        let AppMode::CredentialInput {
+            server,
+            mode,
+            verbose,
+            input,
+            ..
+        } = &self.app_mode
+        else {
+            return None;
+        };
+
+        if input.is_empty() {
+            return None;
+        }
+
+        let result = ((**server).clone(), *mode, *verbose, input.clone());
+        self.app_mode = AppMode::Normal;
+        Some(result)
+    }
+
     /// Calcule la cle unique d'un serveur (stable, independante de l'ordre de config).
     pub fn server_key(server: &ResolvedServer) -> String {
         let mut key = String::new();

--- a/src/app/tests_credential_input.rs
+++ b/src/app/tests_credential_input.rs
@@ -1,0 +1,206 @@
+use super::tests_helpers::make_namespace_config;
+use super::*;
+
+fn direct_server() -> ResolvedServer {
+    ResolvedServer {
+        namespace: String::new(),
+        group_name: "G".into(),
+        env_name: "E".into(),
+        name: "srv".into(),
+        host: "198.51.100.1".into(),
+        user: "admin".into(),
+        port: 22,
+        ssh_key: "~/.ssh/id_ed25519".into(),
+        ssh_options: vec![],
+        default_mode: ConnectionMode::Direct,
+        jump_host: None,
+        bastion_host: None,
+        bastion_user: None,
+        bastion_template: "{target_user}@%n:SSH:{bastion_user}".into(),
+        use_system_ssh_config: false,
+        probe_filesystems: vec![],
+        tunnels: vec![],
+        tags: vec![],
+        control_master: false,
+        control_path: String::new(),
+        control_persist: "10m".to_string(),
+        pre_connect_hook: None,
+        post_disconnect_hook: None,
+        hook_timeout_secs: 5,
+        wallix_group: None,
+        wallix_account: "default".to_string(),
+        wallix_protocol: "SSH".to_string(),
+        wallix_auto_select: true,
+        wallix_fail_if_menu_match_error: true,
+        wallix_selection_timeout_secs: 8,
+    }
+}
+
+fn make_app() -> App {
+    App::new(
+        make_namespace_config(),
+        vec![],
+        std::path::PathBuf::new(),
+        vec![],
+    )
+    .unwrap()
+}
+
+#[test]
+fn open_credential_input_sets_mode_passphrase() {
+    let mut app = make_app();
+    // Manually put a server in the selection state to simulate open_credential_input
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: true,
+        input: String::new(),
+    };
+
+    assert!(matches!(
+        &app.app_mode,
+        AppMode::CredentialInput { is_passphrase: true, .. }
+    ));
+}
+
+#[test]
+fn open_credential_input_sets_mode_password() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: false,
+        input: String::new(),
+    };
+
+    assert!(matches!(
+        &app.app_mode,
+        AppMode::CredentialInput { is_passphrase: false, .. }
+    ));
+}
+
+#[test]
+fn credential_input_char_appends_to_buffer() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: true,
+        input: String::new(),
+    };
+
+    app.credential_input_push('s');
+    app.credential_input_push('e');
+    app.credential_input_push('c');
+
+    assert!(matches!(
+        &app.app_mode,
+        AppMode::CredentialInput { input, .. } if input == "sec"
+    ));
+}
+
+#[test]
+fn credential_input_backspace_removes_last_char() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: true,
+        input: "abc".into(),
+    };
+
+    app.credential_input_backspace();
+
+    assert!(matches!(
+        &app.app_mode,
+        AppMode::CredentialInput { input, .. } if input == "ab"
+    ));
+}
+
+#[test]
+fn credential_input_backspace_on_empty_is_noop() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: true,
+        input: String::new(),
+    };
+
+    app.credential_input_backspace();
+
+    assert!(matches!(
+        &app.app_mode,
+        AppMode::CredentialInput { input, .. } if input.is_empty()
+    ));
+}
+
+#[test]
+fn credential_input_cancel_returns_to_normal() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: true,
+        input: "secret".into(),
+    };
+
+    app.cancel_credential_input();
+
+    assert!(matches!(app.app_mode, AppMode::Normal));
+}
+
+#[test]
+fn credential_input_submit_returns_server_and_cred() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server.clone()),
+        mode: ConnectionMode::Direct,
+        verbose: true,
+        is_passphrase: true,
+        input: "my_passphrase".into(),
+    };
+
+    let result = app.submit_credential_input();
+
+    assert!(result.is_some());
+    let (ret_server, mode, verbose, cred) = result.unwrap();
+    assert_eq!(ret_server.name, "srv");
+    assert_eq!(mode, ConnectionMode::Direct);
+    assert!(verbose);
+    assert_eq!(cred, "my_passphrase");
+    assert!(matches!(app.app_mode, AppMode::Normal));
+}
+
+#[test]
+fn credential_input_submit_empty_is_none() {
+    let mut app = make_app();
+    let server = direct_server();
+    app.app_mode = AppMode::CredentialInput {
+        server: Box::new(server),
+        mode: ConnectionMode::Direct,
+        verbose: false,
+        is_passphrase: true,
+        input: String::new(),
+    };
+
+    let result = app.submit_credential_input();
+
+    // Empty credential → do not submit
+    assert!(result.is_none());
+    // Mode is unchanged
+    assert!(matches!(app.app_mode, AppMode::CredentialInput { .. }));
+}

--- a/src/app/tests_wallix.rs
+++ b/src/app/tests_wallix.rs
@@ -98,7 +98,7 @@ fn wallix_poll_auto_resolves_to_pending_connection() {
     assert!(app.wallix_selector.is_none());
     let pending = app.take_pending_wallix_connection();
     assert!(pending.is_some());
-    let (_, selected_id) = pending.unwrap();
+    let (_, selected_id, _) = pending.unwrap();
     assert_eq!(selected_id, "42");
     assert_eq!(
         app.wallix_selection_cache.get(&App::server_key(&server)),
@@ -228,7 +228,7 @@ fn wallix_poll_uses_cached_selection_when_available() {
     assert!(app.wallix_selector.is_none());
     let pending = app.take_pending_wallix_connection();
     assert!(pending.is_some());
-    let (_, selected_id) = pending.unwrap();
+    let (_, selected_id, _) = pending.unwrap();
     assert_eq!(selected_id, "77");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect};
 use susshi::app::{
     App, AppMode, CmdState, ConfigItem, ScpState, TunnelOverlayState, WallixSelectorState,
 };
+use susshi::fl;
 use susshi::config::{Config, ConnectionMode, IncludeWarning, ResolvedServer, undefined_vars};
 use susshi::handlers::{get_layout, handle_mouse_event, is_in_rect};
 use susshi::import;
@@ -412,6 +413,8 @@ fn build_adhoc_server(
 // ─── main ─────────────────────────────────────────────────────────────────────
 
 fn main() -> io::Result<()> {
+    susshi::i18n::init();
+
     let cli = Cli::parse();
 
     // Résolution du chemin de config
@@ -477,7 +480,7 @@ fn main() -> io::Result<()> {
             return Err(io::Error::other(e.to_string()));
         }
         // post_disconnect_hook non supporté ici : exec() remplace le processus.
-        if let Err(e) = susshi::ssh::client::connect(&server, mode, cli.verbose) {
+        if let Err(e) = susshi::ssh::client::connect(&server, mode, cli.verbose, None) {
             eprintln!("SSH Connection Error: {}", e);
             return Err(io::Error::other(e.to_string()));
         }
@@ -521,7 +524,7 @@ fn main() -> io::Result<()> {
                         eprintln!("Hook pre_connect a annulé la connexion : {e}");
                     } else {
                         if let Err(e) =
-                            susshi::ssh::client::connect_blocking(&server, mode, verbose)
+                            susshi::ssh::client::connect_blocking(&server, mode, verbose, None)
                         {
                             eprintln!("SSH Connection Error: {}", e);
                         }
@@ -540,14 +543,14 @@ fn main() -> io::Result<()> {
                         eprintln!("Hook pre_connect a annulé la connexion : {e}");
                     } else {
                         // post_disconnect_hook non supporté ici : exec() remplace le processus.
-                        if let Err(e) = susshi::ssh::client::connect(&server, mode, verbose) {
+                        if let Err(e) = susshi::ssh::client::connect(&server, mode, verbose, None) {
                             eprintln!("SSH Connection Error: {}", e);
                         }
                     }
                     break;
                 }
             }
-            Ok(AppResult::ConnectWallixSelected(server, verbose, selected_id)) => {
+            Ok(AppResult::ConnectWallixSelected(server, verbose, selected_id, auth)) => {
                 if app.keep_open {
                     if let Err(e) = susshi::hooks::run_hook(
                         server.pre_connect_hook.as_deref().unwrap_or(""),
@@ -559,6 +562,7 @@ fn main() -> io::Result<()> {
                             &server,
                             verbose,
                             &selected_id,
+                            auth.as_deref(),
                         ) {
                             eprintln!("SSH Connection Error: {}", e);
                         }
@@ -577,6 +581,45 @@ fn main() -> io::Result<()> {
                         &server,
                         verbose,
                         &selected_id,
+                        auth.as_deref(),
+                    ) {
+                        eprintln!("SSH Connection Error: {}", e);
+                    }
+                    break;
+                }
+            }
+            Ok(AppResult::ConnectWithAuth(server, mode, verbose, cred)) => {
+                if app.keep_open {
+                    if let Err(e) = susshi::hooks::run_hook(
+                        server.pre_connect_hook.as_deref().unwrap_or(""),
+                        &server,
+                    ) {
+                        eprintln!("Hook pre_connect a annulé la connexion : {e}");
+                    } else {
+                        if let Err(e) = susshi::ssh::client::connect_blocking(
+                            &server,
+                            mode,
+                            verbose,
+                            Some(cred.as_str()),
+                        ) {
+                            eprintln!("SSH Connection Error: {}", e);
+                        }
+                        let _ = susshi::hooks::run_hook(
+                            server.post_disconnect_hook.as_deref().unwrap_or(""),
+                            &server,
+                        );
+                    }
+                } else {
+                    if let Err(e) = susshi::hooks::run_hook(
+                        server.pre_connect_hook.as_deref().unwrap_or(""),
+                        &server,
+                    ) {
+                        eprintln!("Hook pre_connect a annulé la connexion : {e}");
+                    } else if let Err(e) = susshi::ssh::client::connect(
+                        &server,
+                        mode,
+                        verbose,
+                        Some(cred.as_str()),
                     ) {
                         eprintln!("SSH Connection Error: {}", e);
                     }
@@ -598,7 +641,9 @@ fn main() -> io::Result<()> {
 pub enum AppResult {
     Exit,
     Connect(Box<susshi::config::ResolvedServer>, ConnectionMode, bool),
-    ConnectWallixSelected(Box<susshi::config::ResolvedServer>, bool, String),
+    ConnectWallixSelected(Box<susshi::config::ResolvedServer>, bool, String, Option<String>),
+    /// Connexion avec un credential (passphrase ou mot de passe) saisi dans la TUI.
+    ConnectWithAuth(Box<susshi::config::ResolvedServer>, ConnectionMode, bool, String),
 }
 
 fn run_app(
@@ -638,12 +683,13 @@ fn run_app(
         // Lit le résultat du chargement du menu Wallix si un thread tourne
         app.poll_wallix_selector();
 
-        if let Some((server, selected_id)) = app.take_pending_wallix_connection() {
+        if let Some((server, selected_id, auth)) = app.take_pending_wallix_connection() {
             app.record_connection(&server);
             return Ok(AppResult::ConnectWallixSelected(
                 Box::new(server),
                 app.verbose_mode,
                 selected_id,
+                auth,
             ));
         }
 
@@ -656,7 +702,33 @@ fn run_app(
         if event::poll(Duration::from_millis(250))? {
             match event::read()? {
                 Event::Key(key) => {
-                    if app.app_mode != AppMode::Normal {
+                    if let AppMode::CredentialInput { .. } = &app.app_mode {
+                        match key.code {
+                            KeyCode::Esc => {
+                                app.cancel_credential_input();
+                            }
+                            KeyCode::Enter => {
+                                if let Some((server, mode, verbose, cred)) =
+                                    app.submit_credential_input()
+                                {
+                                    app.record_connection(&server);
+                                    return Ok(AppResult::ConnectWithAuth(
+                                        Box::new(server),
+                                        mode,
+                                        verbose,
+                                        cred,
+                                    ));
+                                }
+                            }
+                            KeyCode::Char(c) => {
+                                app.credential_input_push(c);
+                            }
+                            KeyCode::Backspace => {
+                                app.credential_input_backspace();
+                            }
+                            _ => {}
+                        }
+                    } else if app.app_mode != AppMode::Normal {
                         // En mode erreur : n'importe quelle touche ferme le panneau
                         match key.code {
                             KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => app.clear_error(),
@@ -754,6 +826,7 @@ fn run_app(
                                         Box::new(server),
                                         app.verbose_mode,
                                         selected_id,
+                                        app.wallix_pending_auth.take(),
                                     ));
                                 }
                             }
@@ -848,23 +921,27 @@ fn run_app(
                                             match app.clipboard.as_mut().map(|cb| cb.set_text(&cmd))
                                             {
                                                 Some(Ok(_)) => app.set_status_message(
-                                                    app.lang.copied.replacen("{}", &cmd, 1),
+                                                    fl!("copied", cmd = cmd.as_str()),
                                                 ),
-                                                Some(Err(e)) => app.set_status_message(
-                                                    app.lang.clipboard_error.replacen(
-                                                        "{}",
-                                                        &e.to_string(),
-                                                        1,
-                                                    ),
-                                                ),
+                                                Some(Err(e)) => {
+                                                    let err = e.to_string();
+                                                    app.set_status_message(fl!(
+                                                        "clipboard-error",
+                                                        error = err.as_str()
+                                                    ));
+                                                }
                                                 None => app.set_status_message(
-                                                    app.lang.clipboard_unavailable.to_string(),
+                                                    fl!("clipboard-unavailable"),
                                                 ),
                                             }
                                         }
-                                        Err(e) => app.set_status_message(
-                                            app.lang.ssh_error.replacen("{}", &e.to_string(), 1),
-                                        ),
+                                        Err(e) => {
+                                            let err = e.to_string();
+                                            app.set_status_message(fl!(
+                                                "ssh-error",
+                                                error = err.as_str()
+                                            ));
+                                        }
                                     }
                                 }
                             }
@@ -873,11 +950,7 @@ fn run_app(
                             }
                             KeyCode::Char('r') => match app.reload() {
                                 Ok(()) => {}
-                                Err(e) => app.set_status_message(
-                                    app.lang
-                                        .config_reload_error
-                                        .replacen("{}", &e.to_string(), 1),
-                                ),
+                                Err(_) => app.set_status_message(fl!("config-reload-error")),
                             },
                             KeyCode::Char('f') => {
                                 app.toggle_favorite();
@@ -892,11 +965,21 @@ fn run_app(
                                 app.sort_by_recent = !app.sort_by_recent;
                                 app.items_dirty = true;
                                 let msg = if app.sort_by_recent {
-                                    app.lang.sort_recent_on
+                                    fl!("sort-recent-on")
                                 } else {
-                                    app.lang.sort_recent_off
+                                    fl!("sort-recent-off")
                                 };
                                 app.set_status_message(msg);
+                            }
+                            KeyCode::Char('p') => {
+                                // Prompt de credential SSH (passphrase clé ou mot de passe)
+                                let items = app.get_visible_items();
+                                if let Some(ConfigItem::Server(server)) =
+                                    items.get(app.selected_index)
+                                {
+                                    let has_key = !server.ssh_key.is_empty();
+                                    app.open_credential_input(has_key);
+                                }
                             }
                             KeyCode::Char('x') => {
                                 // Lance la saisie de commande ad-hoc

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -145,7 +145,19 @@ pub fn build_ssh_args(
 }
 
 /// Lance la connexion SSH en remplaçant le processus courant (`exec`).
-pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> Result<()> {
+///
+/// Si `credential` est fourni, le processus courant est remplacé par un sous-processus
+/// bloquant (pas d'`exec`) afin de pouvoir configurer `SSH_ASKPASS` et nettoyer le script
+/// temporaire après la session.
+pub fn connect(
+    server: &ResolvedServer,
+    mode: ConnectionMode,
+    verbose: bool,
+    credential: Option<&str>,
+) -> Result<()> {
+    if let Some(cred) = credential {
+        return connect_blocking(server, mode, verbose, Some(cred));
+    }
     let args = build_ssh_args(server, mode, verbose)?;
     let mut command = Command::new("ssh");
     command.args(&args);
@@ -166,31 +178,78 @@ pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> 
 /// Lance la connexion SSH dans un sous-processus bloquant (sans `exec`).
 /// Contrairement à [`connect`], retourne après la fin de la session SSH —
 /// utilisé quand `keep_open` est actif pour revenir à la TUI ensuite.
+///
+/// Si `credential` est fourni, `SSH_ASKPASS` est configuré pour l'injecter
+/// automatiquement lorsque SSH demande une passphrase ou un mot de passe.
 pub fn connect_blocking(
     server: &ResolvedServer,
     mode: ConnectionMode,
     verbose: bool,
+    credential: Option<&str>,
 ) -> Result<()> {
     let args = build_ssh_args(server, mode, verbose)?;
-    Command::new("ssh")
-        .args(&args)
+    let mut command = Command::new("ssh");
+    command.args(&args);
+
+    #[cfg(unix)]
+    let askpass_path = if let Some(cred) = credential {
+        let p = setup_askpass_script(cred)?;
+        command.env("SSH_ASKPASS", &p);
+        command.env("SSH_ASKPASS_REQUIRE", "force");
+        Some(p)
+    } else {
+        None
+    };
+
+    let result = command
         .status()
         .map(|_| ())
-        .map_err(|e| anyhow::Error::new(e).context("Failed to spawn ssh command"))
+        .map_err(|e| anyhow::Error::new(e).context("Failed to spawn ssh command"));
+
+    #[cfg(unix)]
+    if let Some(p) = askpass_path {
+        let _ = std::fs::remove_file(p);
+    }
+
+    result
 }
 
 /// Récupère les entrées du menu Wallix affichées par le bastion sans ouvrir de shell distant.
+///
+/// `auth` est un credential optionnel (passphrase de clé SSH ou mot de passe) à injecter
+/// automatiquement si SSH le demande avant d'afficher le menu.
+/// Si `auth` est `None` et qu'un prompt d'authentification est détecté, retourne une erreur
+/// avec le préfixe `"SSH_AUTH_REQUIRED: "` pour que la TUI affiche le dialog de saisie.
 #[cfg(unix)]
 pub fn fetch_wallix_menu_entries(
     server: &ResolvedServer,
     verbose: bool,
+    auth: Option<&str>,
 ) -> Result<Vec<WallixMenuEntry>> {
     let args = build_wallix_bastion_args(server, verbose)?;
     let (child, mut master_reader, mut master_writer) = spawn_wallix_pty(&args)?;
     let mut transcript = String::new();
 
     loop {
-        let page = read_until_wallix_prompt(&mut master_reader)?;
+        let page = read_until_wallix_prompt_or_auth(&mut master_reader)?;
+
+        if let Some(auth_prompt) = page.strip_prefix("SSH_AUTH_REQUIRED:") {
+            if let Some(cred) = auth {
+                master_writer.write_all(cred.as_bytes())?;
+                master_writer.write_all(b"\n")?;
+                master_writer.flush()?;
+                // Continuer à lire jusqu'au menu Wallix
+                transcript.clear();
+                continue;
+            } else {
+                unsafe {
+                    libc::kill(child.as_raw(), libc::SIGTERM);
+                }
+                let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                return Err(anyhow::anyhow!("SSH_AUTH_REQUIRED: {}", auth_prompt.trim()));
+            }
+        }
+
         transcript.push_str(&page);
 
         match parse_wallix_page_position(&page) {
@@ -213,23 +272,28 @@ pub fn fetch_wallix_menu_entries(
 pub fn fetch_wallix_menu_entries(
     _server: &ResolvedServer,
     _verbose: bool,
+    _auth: Option<&str>,
 ) -> Result<Vec<WallixMenuEntry>> {
     anyhow::bail!("Wallix menu fetching is only supported on Unix")
 }
 
 /// Lance une session Wallix en forçant un ID déjà choisi côté TUI.
+///
+/// `auth` est un credential optionnel (passphrase ou mot de passe) à injecter
+/// automatiquement si SSH le demande pendant la session.
 pub fn connect_wallix_with_selection(
     server: &ResolvedServer,
     verbose: bool,
     selected_id: &str,
+    auth: Option<&str>,
 ) -> Result<()> {
     #[cfg(unix)]
     {
-        connect_wallix_via_pty_with_selection(server, verbose, Some(selected_id))
+        connect_wallix_via_pty_with_selection(server, verbose, Some(selected_id), auth)
     }
     #[cfg(not(unix))]
     {
-        let _ = (server, verbose, selected_id);
+        let _ = (server, verbose, selected_id, auth);
         anyhow::bail!("Wallix menu automation is only supported on Unix")
     }
 }
@@ -239,11 +303,28 @@ pub fn connect_blocking_wallix_with_selection(
     server: &ResolvedServer,
     verbose: bool,
     selected_id: &str,
+    auth: Option<&str>,
 ) -> Result<()> {
-    connect_wallix_with_selection(server, verbose, selected_id)
+    connect_wallix_with_selection(server, verbose, selected_id, auth)
 }
 
 // ─── helpers privés ──────────────────────────────────────────────────────────
+
+/// Crée un script shell temporaire qui affiche `credential` sur stdout, utilisé
+/// comme `SSH_ASKPASS`. Le script est créé avec les permissions 700.
+/// L'appelant est responsable de supprimer le fichier après usage.
+#[cfg(unix)]
+fn setup_askpass_script(credential: &str) -> Result<std::path::PathBuf> {
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt as _;
+    let path = std::env::temp_dir().join(format!("susshi-askpass-{}", std::process::id()));
+    let escaped = credential.replace('\'', r"'\''");
+    let script = format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", escaped);
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(script.as_bytes())?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))?;
+    Ok(path)
+}
 
 #[cfg(unix)]
 fn build_wallix_bastion_args(server: &ResolvedServer, verbose: bool) -> Result<Vec<String>> {
@@ -305,6 +386,14 @@ fn current_winsize() -> Option<Winsize> {
 
     let rc = unsafe { libc::ioctl(libc::STDIN_FILENO, libc::TIOCGWINSZ, &mut winsize) };
     if rc == 0 { Some(winsize) } else { None }
+}
+
+/// Détecte une demande d'authentification SSH (passphrase de clé ou mot de passe).
+/// Utilisé pour intercepter ces prompts dans la boucle PTY Wallix.
+#[cfg(unix)]
+fn contains_ssh_auth_prompt(buffer: &str) -> bool {
+    let lower = buffer.to_ascii_lowercase();
+    lower.contains("enter passphrase for key") || lower.contains("password:")
 }
 
 #[cfg(unix)]
@@ -399,6 +488,7 @@ fn spawn_wallix_pty(args: &[String]) -> Result<(nix::unistd::Pid, std::fs::File,
 }
 
 #[cfg(unix)]
+#[allow(dead_code)]
 fn read_until_wallix_prompt(master_reader: &mut std::fs::File) -> Result<String> {
     let mut transcript = String::new();
     loop {
@@ -425,11 +515,45 @@ fn read_until_wallix_prompt(master_reader: &mut std::fs::File) -> Result<String>
     ))
 }
 
+/// Variante de [`read_until_wallix_prompt`] qui s'arrête aussi sur un prompt d'auth SSH.
+/// Retourne un résultat préfixé par `"SSH_AUTH_REQUIRED:"` si un tel prompt est détecté.
+#[cfg(unix)]
+fn read_until_wallix_prompt_or_auth(master_reader: &mut std::fs::File) -> Result<String> {
+    let mut transcript = String::new();
+    loop {
+        let mut buf = [0_u8; 4096];
+        let read = master_reader.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+
+        let chunk = String::from_utf8_lossy(&buf[..read]);
+        transcript.push_str(&chunk);
+        if transcript.len() > 64 * 1024 {
+            let drain = transcript.len().saturating_sub(64 * 1024);
+            transcript.drain(..drain);
+        }
+
+        if contains_wallix_prompt(&transcript) {
+            return Ok(transcript);
+        }
+
+        if contains_ssh_auth_prompt(&transcript) {
+            return Ok(format!("SSH_AUTH_REQUIRED:{transcript}"));
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "Wallix session exited before the selection prompt was displayed"
+    ))
+}
+
 #[cfg(unix)]
 fn connect_wallix_via_pty_with_selection(
     server: &ResolvedServer,
     verbose: bool,
     selected_id: Option<&str>,
+    auth: Option<&str>,
 ) -> Result<()> {
     let args = build_wallix_bastion_args(server, verbose)?;
     let (child, mut master_reader, mut master_writer) = spawn_wallix_pty(&args)?;
@@ -443,6 +567,10 @@ fn connect_wallix_via_pty_with_selection(
     // Si un ID est déjà connu (fallback TUI), on masque le menu global Wallix
     // pour éviter l'affichage interactif dans le terminal utilisateur.
     let hide_menu_output = selected_id.is_some();
+    // `auth_prompted` devient true dès qu'un prompt SSH auth est détecté.
+    // Quand true, on affiche toujours la sortie et on active stdin pour que
+    // l'utilisateur puisse répondre (ou pour injecter le credential automatiquement).
+    let mut auth_prompted = false;
     let master_fd = master_reader.as_raw_fd();
     let stdin_fd = std::io::stdin().as_raw_fd();
 
@@ -454,7 +582,9 @@ fn connect_wallix_via_pty_with_selection(
                 revents: 0,
             },
             libc::pollfd {
-                fd: if stdin_closed || !selection_completed {
+                fd: if stdin_closed
+                    || !(selection_completed || auth_prompted && auth.is_none())
+                {
                     -1
                 } else {
                     stdin_fd
@@ -487,9 +617,23 @@ fn connect_wallix_via_pty_with_selection(
                 transcript.drain(..drain);
             }
 
+            // Détection d'un prompt d'auth SSH avant le menu Wallix.
+            if !auth_prompted && !selection_completed && contains_ssh_auth_prompt(&transcript) {
+                auth_prompted = true;
+                if let Some(cred) = auth {
+                    // Credential connu → injection automatique silencieuse.
+                    master_writer.write_all(cred.as_bytes())?;
+                    master_writer.write_all(b"\n")?;
+                    master_writer.flush()?;
+                }
+                // Si auth.is_none(), stdin est activé dans pollfds (voir ci-dessus)
+                // et l'output est affiché ci-dessous pour que l'utilisateur voit le prompt.
+            }
+
             // En mode auto-sélection, on n'affiche rien tant que la phase menu
             // n'est pas terminée afin d'éviter le bruit du menu global.
-            if !hide_menu_output || target_address_sent {
+            // Exception : toujours montrer les prompts d'auth sans credential connu.
+            if !hide_menu_output || target_address_sent || (auth_prompted && auth.is_none()) {
                 stdout.write_all(&buf[..read])?;
                 stdout.flush()?;
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -52,8 +52,13 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         overlays::draw_wallix_selector_overlay(f, app, f.area());
     }
 
+    // Overlay saisie credential — au-dessus de tout sauf les erreurs
+    if matches!(&app.app_mode, AppMode::CredentialInput { .. }) {
+        overlays::draw_credential_input_overlay(f, app, f.area());
+    }
+
     // Overlay erreur — rendu en dernier pour être au-dessus de tout
     if let AppMode::Error(msg) = &app.app_mode {
-        overlays::draw_error_overlay(f, msg.clone(), f.area(), app.theme, app.lang);
+        overlays::draw_error_overlay(f, msg.clone(), f.area(), app.theme);
     }
 }

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -7,29 +7,23 @@ use ratatui::{
 };
 
 use crate::app::{
-    App, ConfigItem, ScpFormField, ScpState, TunnelFormField, TunnelOverlayState,
+    App, AppMode, ConfigItem, ScpFormField, ScpState, TunnelFormField, TunnelOverlayState,
     WallixSelectorState,
 };
-use crate::i18n::Strings;
+use crate::fl;
 use crate::ssh::sftp::ScpDirection;
 use crate::ssh::tunnel::TunnelStatus;
 use crate::ui::theme::Theme;
 
-/// Rectangle centre de taille fixe dans `area`.
+/// Rectangle centré de taille fixe dans `area`.
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     let x = area.x + area.width.saturating_sub(width) / 2;
     let y = area.y + area.height.saturating_sub(height) / 2;
     Rect::new(x, y, width.min(area.width), height.min(area.height))
 }
 
-/// Panneau d'erreur centre, affiche par-dessus l'interface normale.
-pub(crate) fn draw_error_overlay(
-    f: &mut Frame,
-    msg: String,
-    area: Rect,
-    theme: &Theme,
-    lang: &Strings,
-) {
+/// Panneau d'erreur centré, affiché par-dessus l'interface normale.
+pub(crate) fn draw_error_overlay(f: &mut Frame, msg: String, area: Rect, theme: &Theme) {
     let lines: Vec<&str> = msg.lines().collect();
     let inner_h = (lines.len() as u16).max(1);
     let popup_h = inner_h + 5;
@@ -41,7 +35,7 @@ pub(crate) fn draw_error_overlay(
     f.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(lang.error_title)
+        .title(fl!("error-title"))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.red))
@@ -62,7 +56,7 @@ pub(crate) fn draw_error_overlay(
     let paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
     f.render_widget(paragraph, chunks[0]);
 
-    let hint = Paragraph::new(lang.error_dismiss).style(Style::default().fg(theme.subtext0));
+    let hint = Paragraph::new(fl!("error-dismiss")).style(Style::default().fg(theme.subtext0));
     f.render_widget(hint, chunks[1]);
 }
 
@@ -75,7 +69,7 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
     f.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(app.lang.wallix_selector_title)
+        .title(fl!("wallix-selector-title"))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(app.theme.sapphire))
@@ -84,7 +78,7 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
     f.render_widget(block, popup_area);
 
     match state {
-        WallixSelectorState::Loading { server } => {
+        WallixSelectorState::Loading { server, .. } => {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
@@ -94,21 +88,18 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
                 ])
                 .split(inner);
             f.render_widget(
-                Paragraph::new(crate::i18n::fmt(
-                    app.lang.wallix_selector_loading,
-                    &[&server.name],
-                ))
-                .style(Style::default().fg(app.theme.fg)),
+                Paragraph::new(fl!("wallix-selector-loading", server = server.name.as_str()))
+                    .style(Style::default().fg(app.theme.fg)),
                 chunks[0],
             );
             f.render_widget(
-                Paragraph::new(app.lang.wallix_selector_loading_hint)
+                Paragraph::new(fl!("wallix-selector-loading-hint"))
                     .style(Style::default().fg(app.theme.subtext0))
                     .wrap(Wrap { trim: true }),
                 chunks[1],
             );
             f.render_widget(
-                Paragraph::new(app.lang.wallix_selector_cancel_hint)
+                Paragraph::new(fl!("wallix-selector-cancel-hint"))
                     .style(Style::default().fg(app.theme.subtext0)),
                 chunks[2],
             );
@@ -123,15 +114,12 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
                 ])
                 .split(inner);
             f.render_widget(
-                Paragraph::new(crate::i18n::fmt(
-                    app.lang.wallix_selector_error,
-                    &[&server.name],
-                ))
-                .style(
-                    Style::default()
-                        .fg(app.theme.red)
-                        .add_modifier(Modifier::BOLD),
-                ),
+                Paragraph::new(fl!("wallix-selector-error", server = server.name.as_str()))
+                    .style(
+                        Style::default()
+                            .fg(app.theme.red)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 chunks[0],
             );
             f.render_widget(
@@ -141,7 +129,7 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
                 chunks[1],
             );
             f.render_widget(
-                Paragraph::new(app.lang.wallix_selector_close_hint)
+                Paragraph::new(fl!("wallix-selector-close-hint"))
                     .style(Style::default().fg(app.theme.subtext0)),
                 chunks[2],
             );
@@ -161,9 +149,10 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
                 .split(inner);
 
             f.render_widget(
-                Paragraph::new(crate::i18n::fmt(
-                    app.lang.wallix_selector_choose,
-                    &[&server.name, &server.host],
+                Paragraph::new(fl!(
+                    "wallix-selector-choose",
+                    server = server.name.as_str(),
+                    host = server.host.as_str()
                 ))
                 .style(Style::default().fg(app.theme.fg)),
                 chunks[0],
@@ -198,7 +187,7 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
             f.render_widget(List::new(items), chunks[1]);
 
             f.render_widget(
-                Paragraph::new(app.lang.wallix_selector_list_hint)
+                Paragraph::new(fl!("wallix-selector-list-hint"))
                     .style(Style::default().fg(app.theme.subtext0)),
                 chunks[2],
             );
@@ -206,7 +195,7 @@ pub(crate) fn draw_wallix_selector_overlay(f: &mut Frame, app: &mut App, area: R
     }
 }
 
-/// Overlay flottant centre listant les tunnels SSH d'un serveur.
+/// Overlay flottant centré listant les tunnels SSH d'un serveur.
 pub(crate) fn draw_tunnel_overlay(f: &mut Frame, app: &mut App, area: Rect) {
     match &app.tunnel_overlay {
         Some(TunnelOverlayState::Form(_)) => {
@@ -319,7 +308,7 @@ pub(crate) fn draw_tunnel_overlay(f: &mut Frame, app: &mut App, area: Rect) {
         app.theme.green
     };
     list_items.push(ListItem::new(Line::from(Span::styled(
-        app.lang.tunnel_overlay_new,
+        fl!("tunnel-overlay-new"),
         Style::default().fg(plus_fg).bg(plus_bg),
     ))));
 
@@ -332,16 +321,16 @@ pub(crate) fn draw_tunnel_overlay(f: &mut Frame, app: &mut App, area: Rect) {
 
     let s = Style::default().fg(app.theme.subtext0);
     f.render_widget(
-        Paragraph::new(app.lang.tunnel_overlay_hints1).style(s),
+        Paragraph::new(fl!("tunnel-overlay-hints1")).style(s),
         hint_chunks[0],
     );
     f.render_widget(
-        Paragraph::new(app.lang.tunnel_overlay_hints2).style(s),
+        Paragraph::new(fl!("tunnel-overlay-hints2")).style(s),
         hint_chunks[1],
     );
 }
 
-/// Formulaire d'edition / creation d'un tunnel SSH.
+/// Formulaire d'édition / création d'un tunnel SSH.
 fn draw_tunnel_form(f: &mut Frame, app: &mut App, area: Rect) {
     let items = app.get_visible_items();
     let server = match items.get(app.selected_index) {
@@ -355,9 +344,9 @@ fn draw_tunnel_form(f: &mut Frame, app: &mut App, area: Rect) {
 
     let is_edit = form.editing_index.is_some();
     let title = if is_edit {
-        crate::i18n::fmt(app.lang.tunnel_form_edit_title, &[&server.name])
+        fl!("tunnel-form-edit-title", server = server.name.as_str())
     } else {
-        crate::i18n::fmt(app.lang.tunnel_form_new_title, &[&server.name])
+        fl!("tunnel-form-new-title", server = server.name.as_str())
     };
 
     let popup_h: u16 = 11;
@@ -389,27 +378,16 @@ fn draw_tunnel_form(f: &mut Frame, app: &mut App, area: Rect) {
         ])
         .split(inner);
 
+    let label_label = fl!("tunnel-form-field-label");
+    let label_lp = fl!("tunnel-form-field-local-port");
+    let label_rh = fl!("tunnel-form-field-remote-host");
+    let label_rp = fl!("tunnel-form-field-remote-port");
+
     let fields: &[(&str, &str, TunnelFormField)] = &[
-        (
-            app.lang.tunnel_form_field_label,
-            &form.label,
-            TunnelFormField::Label,
-        ),
-        (
-            app.lang.tunnel_form_field_local_port,
-            &form.local_port,
-            TunnelFormField::LocalPort,
-        ),
-        (
-            app.lang.tunnel_form_field_remote_host,
-            &form.remote_host,
-            TunnelFormField::RemoteHost,
-        ),
-        (
-            app.lang.tunnel_form_field_remote_port,
-            &form.remote_port,
-            TunnelFormField::RemotePort,
-        ),
+        (&label_label, &form.label, TunnelFormField::Label),
+        (&label_lp, &form.local_port, TunnelFormField::LocalPort),
+        (&label_rh, &form.remote_host, TunnelFormField::RemoteHost),
+        (&label_rp, &form.remote_port, TunnelFormField::RemotePort),
     ];
 
     for (i, (label, value, field)) in fields.iter().enumerate() {
@@ -441,12 +419,84 @@ fn draw_tunnel_form(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     f.render_widget(
-        Paragraph::new(app.lang.tunnel_form_hint).style(Style::default().fg(app.theme.subtext0)),
+        Paragraph::new(fl!("tunnel-form-hint"))
+            .style(Style::default().fg(app.theme.subtext0)),
         chunks[6],
     );
 }
 
-/// Dispatch entre la selection de direction et le formulaire SCP.
+/// Overlay de saisie de credential SSH (passphrase de clé ou mot de passe).
+///
+/// Affiché lorsque l'utilisateur appuie sur `p` avant une connexion, ou lorsque
+/// le flow Wallix détecte un prompt SSH et que l'utilisateur n'a pas de credential.
+pub(crate) fn draw_credential_input_overlay(f: &mut Frame, app: &App, area: Rect) {
+    let AppMode::CredentialInput {
+        server,
+        is_passphrase,
+        input,
+        ..
+    } = &app.app_mode
+    else {
+        return;
+    };
+
+    let popup_h: u16 = 6;
+    let popup_w: u16 = 56.min(area.width.saturating_sub(4));
+    let popup_area = centered_rect(popup_w, popup_h, area);
+
+    f.render_widget(Clear, popup_area);
+
+    let title = if *is_passphrase {
+        fl!("credential-input-title-passphrase", server = server.name.as_str())
+    } else {
+        fl!("credential-input-title-password", server = server.name.as_str())
+    };
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(app.theme.yellow))
+        .style(Style::default().bg(app.theme.bg));
+
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let label = if *is_passphrase {
+        fl!("credential-input-prompt-passphrase")
+    } else {
+        fl!("credential-input-prompt-password")
+    };
+
+    // Affiche des astérisques à la place des caractères saisis
+    let masked: String = "*".repeat(input.len());
+    let line = Line::from(vec![
+        Span::styled(label, Style::default().fg(app.theme.yellow)),
+        Span::styled(
+            format!("{}█", masked),
+            Style::default().fg(app.theme.fg).bg(app.theme.selection_bg),
+        ),
+    ]);
+    f.render_widget(Paragraph::new(line), chunks[1]);
+
+    f.render_widget(
+        Paragraph::new(fl!("credential-input-hint"))
+            .style(Style::default().fg(app.theme.subtext0)),
+        chunks[3],
+    );
+}
+
+/// Dispatch entre la sélection de direction et le formulaire SCP.
 pub(crate) fn draw_scp_overlay(f: &mut Frame, app: &mut App, area: Rect) {
     match &app.scp_state {
         ScpState::SelectingDirection => draw_scp_direction_select(f, app, area),
@@ -456,7 +506,7 @@ pub(crate) fn draw_scp_overlay(f: &mut Frame, app: &mut App, area: Rect) {
     }
 }
 
-/// Petit overlay de selection de direction (Upload / Download).
+/// Petit overlay de sélection de direction (Upload / Download).
 fn draw_scp_direction_select(f: &mut Frame, app: &mut App, area: Rect) {
     let items = app.get_visible_items();
     let server = match items.get(app.selected_index) {
@@ -471,7 +521,7 @@ fn draw_scp_direction_select(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(crate::i18n::fmt(app.lang.scp_direction_title, &[&server]))
+        .title(fl!("scp-direction-title", server = server.as_str()))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(app.theme.sapphire))
@@ -500,10 +550,10 @@ fn draw_scp_direction_select(f: &mut Frame, app: &mut App, area: Rect) {
         Paragraph::new(Line::from(vec![
             Span::styled("  ↑  ", s_active),
             Span::styled(
-                format!("{}  ", app.lang.scp_direction_upload_label),
+                format!("{}  ", fl!("scp-direction-upload-label")),
                 s_label,
             ),
-            Span::styled(app.lang.scp_direction_upload, s_sub),
+            Span::styled(fl!("scp-direction-upload"), s_sub),
         ])),
         chunks[0],
     );
@@ -511,15 +561,15 @@ fn draw_scp_direction_select(f: &mut Frame, app: &mut App, area: Rect) {
         Paragraph::new(Line::from(vec![
             Span::styled("  ↓  ", s_active),
             Span::styled(
-                format!("{}  ", app.lang.scp_direction_download_label),
+                format!("{}  ", fl!("scp-direction-download-label")),
                 s_label,
             ),
-            Span::styled(app.lang.scp_direction_download, s_sub),
+            Span::styled(fl!("scp-direction-download"), s_sub),
         ])),
         chunks[1],
     );
     f.render_widget(
-        Paragraph::new(app.lang.scp_direction_hint).style(s_sub),
+        Paragraph::new(fl!("scp-direction-hint")).style(s_sub),
         chunks[3],
     );
 }
@@ -549,11 +599,15 @@ fn draw_scp_form(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     let dir_label = if direction == ScpDirection::Upload {
-        app.lang.scp_direction_upload_label
+        fl!("scp-direction-upload-label")
     } else {
-        app.lang.scp_direction_download_label
+        fl!("scp-direction-download-label")
     };
-    let title = crate::i18n::fmt(app.lang.scp_form_title, &[dir_label, &server_name]);
+    let title = fl!(
+        "scp-form-title",
+        direction = dir_label.as_str(),
+        server = server_name.as_str()
+    );
 
     let popup_h: u16 = 8;
     let popup_w: u16 = 64.min(area.width.saturating_sub(4));
@@ -582,13 +636,12 @@ fn draw_scp_form(f: &mut Frame, app: &mut App, area: Rect) {
         ])
         .split(inner);
 
+    let label_local = fl!("scp-form-field-local");
+    let label_remote = fl!("scp-form-field-remote");
+
     let fields: &[(&str, &str, ScpFormField)] = &[
-        (app.lang.scp_form_field_local, &local, ScpFormField::Local),
-        (
-            app.lang.scp_form_field_remote,
-            &remote,
-            ScpFormField::Remote,
-        ),
+        (&label_local, &local, ScpFormField::Local),
+        (&label_remote, &remote, ScpFormField::Remote),
     ];
 
     let inner_w = popup_area.width.saturating_sub(2) as usize;
@@ -634,19 +687,20 @@ fn draw_scp_form(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     f.render_widget(
-        Paragraph::new(app.lang.scp_form_hint).style(Style::default().fg(app.theme.subtext0)),
+        Paragraph::new(fl!("scp-form-hint"))
+            .style(Style::default().fg(app.theme.subtext0)),
         chunks[4],
     );
 }
 
-/// Overlay de resultat SCP (Done / Error) — ferme avec Esc / Enter / q.
+/// Overlay de résultat SCP (Done / Error) — ferme avec Esc / Enter / q.
 fn draw_scp_result(f: &mut Frame, app: &mut App, area: Rect) {
     let (icon, color, msg) = match &app.scp_state {
         ScpState::Done { direction, exit_ok } => {
             let dir_label = if *direction == ScpDirection::Upload {
-                app.lang.scp_direction_upload_label
+                fl!("scp-direction-upload-label")
             } else {
-                app.lang.scp_direction_download_label
+                fl!("scp-direction-download-label")
             };
             let icon = if *exit_ok { "✔" } else { "✗" };
             let color = if *exit_ok {
@@ -655,16 +709,16 @@ fn draw_scp_result(f: &mut Frame, app: &mut App, area: Rect) {
                 app.theme.red
             };
             let msg = if *exit_ok {
-                crate::i18n::fmt(app.lang.scp_result_success, &[dir_label])
+                fl!("scp-result-success", direction = dir_label.as_str())
             } else {
-                crate::i18n::fmt(app.lang.scp_result_errors, &[dir_label])
+                fl!("scp-result-errors", direction = dir_label.as_str())
             };
             (icon, color, msg)
         }
         ScpState::Error(e) => (
             "✗",
             app.theme.red,
-            crate::i18n::fmt(app.lang.scp_result_fail, &[e]),
+            fl!("scp-result-fail", error = e.as_str()),
         ),
         _ => return,
     };
@@ -676,7 +730,7 @@ fn draw_scp_result(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(app.lang.scp_result_title)
+        .title(fl!("scp-result-title"))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(color))
@@ -702,7 +756,8 @@ fn draw_scp_result(f: &mut Frame, app: &mut App, area: Rect) {
         chunks[0],
     );
     f.render_widget(
-        Paragraph::new(app.lang.scp_result_hint).style(Style::default().fg(app.theme.subtext0)),
+        Paragraph::new(fl!("scp-result-hint"))
+            .style(Style::default().fg(app.theme.subtext0)),
         chunks[2],
     );
 }


### PR DESCRIPTION
## Summary

- Adds a credential input overlay (`p` key) for entering an SSH key passphrase or password before connecting, without exposing it in the terminal
- The credential is injected via `SSH_ASKPASS` so SSH never prompts interactively
- Input is masked as asterisks on screen; `Enter` confirms, `Esc` cancels
- The existing Wallix `SSH_AUTH_REQUIRED` path (which already set `AppMode::CredentialInput`) now has a proper keyboard handler — it was silently broken before

## Behaviour details

- If the server has `ssh_key` configured → dialog title says "Passphrase"
- Otherwise → dialog title says "Password"
- Works for Direct, Jump, and Wallix modes
- i18n in English and French

## Test plan

- [ ] Press `p` on a Direct server with a key → passphrase dialog appears with asterisk masking
- [ ] Press `p` on a server without a key → password dialog appears
- [ ] `Enter` with content → connects via `ConnectWithAuth` (SSH_ASKPASS injected)
- [ ] `Enter` with empty input → dialog stays open (no connection)
- [ ] `Esc` → returns to normal list without connecting
- [ ] Wallix with passphrase-protected key → `SSH_AUTH_REQUIRED` dialog appears and credential is used on retry
- [ ] 8 unit tests: `cargo test tests_credential_input` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)