### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.0] — 2026-05-18
+
+### Added
+
+- SSH credential prompt (passphrase / password) in TUI
+
+
+### Changed
+
+- Split app and ui god modules
+
+
+### build
+
+- Bump libc from 0.2.184 to 0.2.186
+
+- Bump libc from 0.2.183 to 0.2.184
+
+
 ## [0.14.0] — 2026-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)

### ⚠ `susshi` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum susshi::i18n::Lang, previously in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:16

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field verbose of variant WallixSelectorState::Loading in /tmp/.tmpeWN6Fe/susshi/src/app.rs:228

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant AppMode:CredentialInput in /tmp/.tmpeWN6Fe/susshi/src/app.rs:60

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function susshi::i18n::fmt, previously in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:647
  function susshi::i18n::detect_lang, previously in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:617
  function susshi::i18n::get_strings, previously in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:632

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  susshi::ssh::client::connect_blocking_wallix_with_selection now takes 4 parameters instead of 3, in /tmp/.tmpeWN6Fe/susshi/src/ssh/client.rs:302
  susshi::ssh::client::fetch_wallix_menu_entries now takes 3 parameters instead of 2, in /tmp/.tmpeWN6Fe/susshi/src/ssh/client.rs:224
  susshi::ssh::client::connect now takes 4 parameters instead of 3, in /tmp/.tmpeWN6Fe/susshi/src/ssh/client.rs:152
  susshi::ssh::client::connect_wallix_with_selection now takes 4 parameters instead of 3, in /tmp/.tmpeWN6Fe/susshi/src/ssh/client.rs:284
  susshi::ssh::client::connect_blocking now takes 4 parameters instead of 3, in /tmp/.tmpeWN6Fe/susshi/src/ssh/client.rs:184

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  susshi::app::TunnelForm::validate takes 1 parameters in /tmp/.tmpIu4Bt4/susshi/src/app.rs:131, but now takes 0 parameters in /tmp/.tmpeWN6Fe/susshi/src/app.rs:180

--- failure pub_static_missing: pub static is missing ---

Description:
A public static is missing, renamed, or made private.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/pub_static_missing.ron

Failed in:
  STRINGS_FR in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:269
  STRINGS_EN in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:442

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct susshi::i18n::Strings, previously in file /tmp/.tmpIu4Bt4/susshi/src/i18n.rs:24

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field lang of struct App, previously in file /tmp/.tmpIu4Bt4/susshi/src/app.rs:302
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0] — 2026-05-18

### Added

- SSH credential prompt (passphrase / password) in TUI


### Changed

- Split app and ui god modules


### build

- Bump libc from 0.2.184 to 0.2.186

- Bump libc from 0.2.183 to 0.2.184
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).