### PR TITLE
fix(ci): downgrade setup-zig from v3 to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Setup Zig
         if: matrix.build_tool == 'zigbuild'
-        uses: goto-bus-stop/setup-zig@v3
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: 0.14.0
 


### PR DESCRIPTION
## Summary

- `goto-bus-stop/setup-zig@v3` does not exist (latest is v2.2.1), causing all binary build jobs in the Release workflow to fail at **Set up job** with:
  ```
  Unable to resolve action `goto-bus-stop/setup-zig@v3`, unable to find version `v3`
  ```
- Downgrade to `@v2` (resolves to v2.2.1, the latest available).

Fixes the v0.15.1 release run: https://github.com/yatoub/susshi/actions/runs/26093569441

## Test plan

- [ ] Merge and re-trigger the Release workflow via `workflow_dispatch` on tag `v0.15.1` to confirm the glibc-2.17 binary is produced successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)