### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.2] — 2026-05-19
+
+### Added
+
+- Show probe results in split pane pinned server panel
+
+- Implement TUI features — help overlay, cmd history, overview, split pane
+
+- Add SSH agent forwarding support (agent_forwarding config key)
+
+
+### Fixed
+
+- Collapse nested if into match guard for cmd history Up key
+
+
+### style
+
+- Apply cargo fmt to test files and overlays
+
+
 ## [0.15.1] — 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.15.1 -> 0.15.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.2] — 2026-05-19

### Added

- Show probe results in split pane pinned server panel

- Implement TUI features — help overlay, cmd history, overview, split pane

- Add SSH agent forwarding support (agent_forwarding config key)


### Fixed

- Collapse nested if into match guard for cmd history Up key


### style

- Apply cargo fmt to test files and overlays
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).