### PR TITLE
fix: overhaul Wallix connection mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
             binary_name: susshi.exe
             asset_name: susshi-windows-amd64.exe
             build_tool: cargo
-            openssl_mode: vendored
+            openssl_mode: system
 
     steps:
       - name: Checkout repository
@@ -79,6 +79,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools pkg-config libssl-dev
+
+      - name: Install OpenSSL for Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install openssl --no-progress -y
+          $opensslDir = "C:\Program Files\OpenSSL-Win64"
+          if (-not (Test-Path $opensslDir)) { $opensslDir = "C:\Program Files\OpenSSL" }
+          echo "OPENSSL_DIR=$opensslDir" >> $env:GITHUB_ENV
+          echo "OPENSSL_NO_VENDOR=1" >> $env:GITHUB_ENV
 
       - name: Setup Zig
         if: matrix.build_tool == 'zigbuild'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode
 .mcp.json
+config/

--- a/docs/wallix.md
+++ b/docs/wallix.md
@@ -87,11 +87,49 @@ When automatic resolution fails (no match or ambiguity), susshi opens a focused 
 - If Wallix asks for a secondary prompt like `Adresse cible`, susshi auto-fills the configured server host.
 - If no reliable match is found, susshi falls back to manual in-session selection.
 
+## Forcing a Specific Authorization
+
+When a target has multiple Wallix authorizations (different groups), set `wallix.authorization` to the exact authorization name shown in the Wallix menu:
+
+```yaml
+groups:
+  - name: "Secured Perimeter"
+    wallix:
+      group: "ces3s-admins"         # short form — used for menu scoring
+    servers:
+      - name: "anscore02"
+        host: "anscore02.internal.example"
+        mode: "wallix"
+        wallix:
+          authorization: "STI-ANSCORE_ces3s-admins"  # exact name from the Wallix menu
+          direct: true
+```
+
+`authorization` takes priority over `group` and is passed verbatim in the SSH login string. Combined with `direct: true`, this gives instant zero-delay connections for servers where the authorization is known in advance.
+
+**When to use:** When `auto_select` resolves the wrong entry, or when a server has multiple authorizations and you want to pin the right one without going through the menu.
+
+## Direct Connection Mode
+
+Set `wallix.direct: true` to bypass the menu probe entirely and connect in zero delay.
+
+```yaml
+defaults:
+  wallix:
+    host: "bastion.example.com"
+    user: "bastion-user"
+    direct: true          # skip menu probe — Wallix connects directly
+```
+
+**When to use:** When Wallix is configured to connect the target directly without presenting a selection menu, or when `wallix.authorization` is set and Wallix will always resolve to a single entry. Without `direct: true`, susshi still detects direct connections automatically — it just takes a few extra seconds.
+
 ## Behavior Controls
 
 - `auto_select`: enable automatic selection attempts.
 - `fail_if_menu_match_error`: keep trying (including pagination) before falling back.
 - `selection_timeout_secs`: menu parsing timeout budget.
+- `authorization`: exact Wallix authorization name — bypasses group matching and pins the entry.
+- `direct`: skip the menu probe and connect immediately (zero-delay).
 
 ## Troubleshooting
 

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -91,6 +91,14 @@ defaults:
     auto_select: true
     fail_if_menu_match_error: true
     selection_timeout_secs: 8
+    # Set to true when the target server always connects directly through Wallix
+    # without presenting a selection menu. Skips the menu probe and connects
+    # instantly — eliminates the ~5 s delay for direct-checkout targets.
+    # direct: true
+    # Exact Wallix authorization name (e.g. "STI-ANSCORE_ces3s-admins").
+    # When set, takes priority over `group` and is passed verbatim in the login
+    # string. Use with direct: true for instant zero-delay connections.
+    # authorization: "PREFIX_group-name"
   # Single jump host
   jump:
     - host: "jump.example.com"
@@ -208,6 +216,14 @@ groups:
         host: "standard-ops.internal.example"
         mode: "wallix"
         # Inherits wallix.group = "ops-admins" from parent group.
+      - name: "anscore02"
+        host: "anscore02.internal.example"
+        mode: "wallix"
+        wallix:
+          # Exact authorization name pins the right entry when multiple groups exist.
+          # Combined with direct: true → instant connection, no menu probe.
+          authorization: "STI-ANSCORE_ces3s-admins"
+          direct: true
 
   - name: "Infrastructure"
     servers:

--- a/src/app/tests_credential_input.rs
+++ b/src/app/tests_credential_input.rs
@@ -34,6 +34,8 @@ fn direct_server() -> ResolvedServer {
         wallix_auto_select: true,
         wallix_fail_if_menu_match_error: true,
         wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
     }
 }
 

--- a/src/app/tests_wallix.rs
+++ b/src/app/tests_wallix.rs
@@ -23,6 +23,8 @@ fn wallix_test_server(group: Option<&str>) -> ResolvedServer {
         wallix_auto_select: true,
         wallix_fail_if_menu_match_error: true,
         wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
         use_system_ssh_config: false,
         probe_filesystems: vec![],
         tunnels: vec![],

--- a/src/app/wallix_state.rs
+++ b/src/app/wallix_state.rs
@@ -73,8 +73,7 @@ pub(super) fn targeted_wallix_entries(
 }
 
 impl App {
-    pub fn should_open_wallix_selector(&self, server: &ResolvedServer) -> bool {
-        let _ = server;
+    pub fn should_open_wallix_selector(&self, _server: &ResolvedServer) -> bool {
         if self.connection_mode != ConnectionMode::Wallix {
             return false;
         }
@@ -91,6 +90,10 @@ impl App {
     }
 
     pub fn open_wallix_selector(&mut self, server: ResolvedServer, verbose: bool) {
+        if server.wallix_direct {
+            self.wallix_pending_connection = Some((server, "WALLIX_DIRECT".to_string()));
+            return;
+        }
         self.open_wallix_selector_with_auth(server, verbose, None);
     }
 
@@ -171,7 +174,18 @@ impl App {
                     }
                 }
                 Err(message) => {
-                    if let Some(prompt_text) = message.strip_prefix("SSH_AUTH_REQUIRED:") {
+                    if message == "WALLIX_DIRECT_CONNECTION" {
+                        // The filtered login caused Wallix to connect directly — trigger
+                        // connection immediately using a sentinel ID that bypasses menu nav.
+                        let verbose = match &self.wallix_selector {
+                            Some(WallixSelectorState::Loading { verbose, .. }) => *verbose,
+                            _ => false,
+                        };
+                        self.wallix_selector = None;
+                        self.wallix_pending_connection =
+                            Some((server, "WALLIX_DIRECT".to_string()));
+                        let _ = verbose;
+                    } else if let Some(prompt_text) = message.strip_prefix("SSH_AUTH_REQUIRED:") {
                         let is_passphrase = prompt_text
                             .to_ascii_lowercase()
                             .contains("enter passphrase for key");

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,11 @@ pub struct BastionConfig {
     pub fail_if_menu_match_error: Option<bool>,
     /// Timeout avant abandon du parsing menu (secondes). Défaut : 8.
     pub selection_timeout_secs: Option<u64>,
+    /// Connexion directe sans menu interactif (login filtré bastion_user@host:proto:bastion_user).
+    pub direct: Option<bool>,
+    /// Nom exact de l'autorisation Wallix (ex: "STI-ANSCORE_ces3s-admins").
+    /// Quand défini, inclus dans le login filtré pour forcer la sélection côté Wallix.
+    pub authorization: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -338,6 +343,10 @@ pub struct ResolvedServer {
     pub wallix_fail_if_menu_match_error: bool,
     /// Timeout avant abandon du parsing menu (secondes).
     pub wallix_selection_timeout_secs: u64,
+    /// Connexion directe sans menu (bypass du probe PTY).
+    pub wallix_direct: bool,
+    /// Nom exact de l'autorisation Wallix — inclus dans le login filtré quand défini.
+    pub wallix_authorization: Option<String>,
     /// Respecte `~/.ssh/config` si `true` (ne passe pas `-F /dev/null`).
     pub use_system_ssh_config: bool,
     /// Points de montage à interroger lors d'un probe (hérités en cascade).
@@ -753,6 +762,8 @@ fn merge_bastion(
             auto_select: c.auto_select.or(p.auto_select),
             fail_if_menu_match_error: c.fail_if_menu_match_error.or(p.fail_if_menu_match_error),
             selection_timeout_secs: c.selection_timeout_secs.or(p.selection_timeout_secs),
+            direct: c.direct.or(p.direct),
+            authorization: c.authorization.clone().or(p.authorization.clone()),
         }),
     }
 }
@@ -1270,6 +1281,11 @@ fn resolve_server(
             .as_ref()
             .and_then(|b| b.selection_timeout_secs)
             .unwrap_or(8),
+        wallix_direct: final_bastion
+            .as_ref()
+            .and_then(|b| b.direct)
+            .unwrap_or(false),
+        wallix_authorization: final_bastion.as_ref().and_then(|b| b.authorization.clone()),
     })
 }
 
@@ -1374,6 +1390,8 @@ mod tests {
             auto_select: None,
             fail_if_menu_match_error: None,
             selection_timeout_secs: None,
+            direct: None,
+            authorization: None,
         });
         let child = BastionConfig {
             host: None,
@@ -1385,6 +1403,8 @@ mod tests {
             auto_select: None,
             fail_if_menu_match_error: None,
             selection_timeout_secs: None,
+            direct: None,
+            authorization: None,
         };
 
         let merged = merge_bastion(&parent, &Some(child)).unwrap();
@@ -1413,6 +1433,8 @@ mod tests {
                     auto_select: None,
                     fail_if_menu_match_error: None,
                     selection_timeout_secs: None,
+                    direct: None,
+                    authorization: None,
                 }),
                 ..Default::default()
             }),

--- a/src/export/ansible.rs
+++ b/src/export/ansible.rs
@@ -234,6 +234,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
         }
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -101,6 +101,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -408,6 +408,8 @@ fn build_adhoc_server(
             .as_ref()
             .and_then(|b| b.selection_timeout_secs)
             .unwrap_or(8),
+        wallix_direct: d.wallix.as_ref().and_then(|b| b.direct).unwrap_or(false),
+        wallix_authorization: d.wallix.as_ref().and_then(|b| b.authorization.clone()),
     }
 }
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -460,6 +460,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -27,14 +27,22 @@ fn build_wallix_login_user(
         || server.bastion_template == "{target_user}@%n:SSH:{bastion_user}"
     {
         let mut login = format!("{}@{}:{}", server.user, target_host, server.wallix_protocol);
-        if let Some(group) = server
-            .wallix_group
+        // wallix_authorization (exact name) takes priority over wallix_group (short name).
+        let qualifier = server
+            .wallix_authorization
             .as_deref()
             .map(str::trim)
-            .filter(|g| !g.is_empty())
-        {
+            .filter(|a| !a.is_empty())
+            .or_else(|| {
+                server
+                    .wallix_group
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|g| !g.is_empty())
+            });
+        if let Some(q) = qualifier {
             login.push(':');
-            login.push_str(group);
+            login.push_str(q);
         }
         login.push(':');
         login.push_str(bastion_user);
@@ -232,36 +240,99 @@ pub fn fetch_wallix_menu_entries(
 ) -> Result<Vec<WallixMenuEntry>> {
     let args = build_wallix_bastion_args(server, verbose)?;
     let (child, mut master_reader, mut master_writer) = spawn_wallix_pty(&args)?;
+    let master_fd = master_reader.as_raw_fd();
     let mut transcript = String::new();
+    let mut auth_injected = false;
+    let timeout_secs = server.wallix_selection_timeout_secs;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
-    loop {
-        let page = read_until_wallix_prompt_or_auth(&mut master_reader)?;
-
-        if let Some(auth_prompt) = page.strip_prefix("SSH_AUTH_REQUIRED:") {
-            if let Some(cred) = auth {
-                master_writer.write_all(cred.as_bytes())?;
-                master_writer.write_all(b"\n")?;
-                master_writer.flush()?;
-                // Continuer à lire jusqu'au menu Wallix
-                transcript.clear();
-                continue;
-            } else {
-                unsafe {
-                    libc::kill(child.as_raw(), libc::SIGTERM);
-                }
+    'outer: loop {
+        // Poll with 200ms slices so we can check the deadline regularly.
+        loop {
+            if std::time::Instant::now() >= deadline {
+                unsafe { libc::kill(child.as_raw(), libc::SIGTERM) };
                 let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
-                return Err(anyhow::anyhow!("SSH_AUTH_REQUIRED: {}", auth_prompt.trim()));
+                return Err(anyhow::anyhow!(
+                    "Wallix menu fetch timed out after {}s without showing a selection prompt",
+                    timeout_secs
+                ));
             }
-        }
 
-        transcript.push_str(&page);
-
-        match parse_wallix_page_position(&page) {
-            Some((current, total)) if current < total => {
-                master_writer.write_all(b"n\n")?;
-                master_writer.flush()?;
+            let mut pfd = libc::pollfd {
+                fd: master_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let rc = unsafe { libc::poll(&mut pfd, 1, 200) };
+            if rc < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                unsafe { libc::kill(child.as_raw(), libc::SIGTERM) };
+                let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                return Err(err.into());
             }
-            _ => break,
+            if rc == 0 {
+                // timeout slice — check deadline on next iteration
+                continue;
+            }
+
+            // Data available.
+            let mut buf = [0_u8; 4096];
+            let read = match master_reader.read(&mut buf) {
+                Ok(0) => break 'outer, // PTY closed
+                Ok(n) => n,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                Err(e) => {
+                    unsafe { libc::kill(child.as_raw(), libc::SIGTERM) };
+                    let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                    return Err(e.into());
+                }
+            };
+
+            let chunk = String::from_utf8_lossy(&buf[..read]);
+            transcript.push_str(&chunk);
+            if transcript.len() > 128 * 1024 {
+                let drain = transcript.len().saturating_sub(128 * 1024);
+                transcript.drain(..drain);
+            }
+
+            // Auth prompt before the menu.
+            if !auth_injected && contains_ssh_auth_prompt(&transcript) {
+                if let Some(cred) = auth {
+                    master_writer.write_all(cred.as_bytes())?;
+                    master_writer.write_all(b"\n")?;
+                    master_writer.flush()?;
+                    auth_injected = true;
+                    transcript.clear();
+                } else {
+                    unsafe { libc::kill(child.as_raw(), libc::SIGTERM) };
+                    let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                    return Err(anyhow::anyhow!("SSH_AUTH_REQUIRED: {}", transcript.trim()));
+                }
+                continue;
+            }
+
+            if wallix_connected_directly(&transcript) {
+                // The filtered login caused Wallix to connect directly without showing a menu.
+                // Kill the probe PTY (the real shell is already open and then closed).
+                unsafe { libc::kill(child.as_raw(), libc::SIGTERM) };
+                let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                return Err(anyhow::anyhow!("WALLIX_DIRECT_CONNECTION"));
+            }
+
+            if contains_wallix_prompt(&transcript) {
+                // Check if there are more pages to fetch.
+                match parse_wallix_page_position(&transcript) {
+                    Some((current, total)) if current < total => {
+                        master_writer.write_all(b"n\n")?;
+                        master_writer.flush()?;
+                        break; // go back to outer loop for next page
+                    }
+                    _ => break 'outer,
+                }
+            }
         }
     }
 
@@ -269,6 +340,11 @@ pub fn fetch_wallix_menu_entries(
         libc::kill(child.as_raw(), libc::SIGTERM);
     }
     let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+
+    if std::env::var("SUSSHI_WALLIX_DEBUG").is_ok() {
+        let _ = std::fs::write("/tmp/susshi-wallix-debug.txt", &transcript);
+    }
+
     parse_wallix_menu(&transcript)
 }
 
@@ -291,6 +367,29 @@ pub fn connect_wallix_with_selection(
     selected_id: &str,
     auth: Option<&str>,
 ) -> Result<()> {
+    // WALLIX_DIRECT: the filtered login (bastion_user@host:protocol:bastion_user) already
+    // connects without a menu. Reuse build_wallix_bastion_args so the login is identical
+    // to the probe that succeeded — build_wallix_login_user uses a different format.
+    if selected_id == "WALLIX_DIRECT" {
+        #[cfg(unix)]
+        {
+            let args = build_wallix_bastion_args(server, verbose)?;
+            let mut command = Command::new("ssh");
+            command.args(&args);
+            if let Some(cred) = auth {
+                let p = setup_askpass_script(cred)?;
+                command.env("SSH_ASKPASS", &p);
+                command.env("SSH_ASKPASS_REQUIRE", "force");
+                let result = command.status().map(|_| ()).map_err(anyhow::Error::from);
+                let _ = std::fs::remove_file(p);
+                return result;
+            }
+            let err = std::os::unix::process::CommandExt::exec(&mut command);
+            return Err(anyhow::Error::new(err).context("Failed to exec ssh command"));
+        }
+        #[cfg(not(unix))]
+        return connect(server, ConnectionMode::Wallix, verbose, auth);
+    }
     #[cfg(unix)]
     {
         connect_wallix_via_pty_with_selection(server, verbose, Some(selected_id), auth)
@@ -367,7 +466,27 @@ fn build_wallix_bastion_args(server: &ResolvedServer, verbose: bool) -> Result<V
 
     let bastion_user = server.bastion_user.as_deref().unwrap_or("root");
     args.push("-l".into());
-    args.push(bastion_user.to_string());
+    // Pass target host in the login to let Wallix filter the menu server-side.
+    // When wallix_authorization is set (e.g. "STI-ANSCORE_ces3s-admins"), include it so
+    // Wallix connects directly without showing a selection menu.
+    // Without authorization, target-only filtering reduces a 27-page menu to 1-2 entries.
+    let (t_host, _) = parse_host_port(&server.host);
+    let filtered_login = if let Some(auth) = server
+        .wallix_authorization
+        .as_deref()
+        .filter(|a| !a.is_empty())
+    {
+        format!(
+            "{}@{}:{}:{}:{}",
+            bastion_user, t_host, server.wallix_protocol, auth, bastion_user
+        )
+    } else {
+        format!(
+            "{}@{}:{}:{}",
+            bastion_user, t_host, server.wallix_protocol, bastion_user
+        )
+    };
+    args.push(filtered_login);
 
     let (b_host, b_port) = parse_host_port(bastion_host_str);
     if let Some(p) = b_port {
@@ -377,6 +496,16 @@ fn build_wallix_bastion_args(server: &ResolvedServer, verbose: bool) -> Result<V
     args.push(b_host.to_string());
 
     Ok(args)
+}
+
+#[cfg(unix)]
+fn wallix_connected_directly(buffer: &str) -> bool {
+    let clean = crate::wallix::strip_ansi(buffer);
+    let lower = clean.to_ascii_lowercase();
+    // Wallix prints this after bypassing the menu and opening a direct shell.
+    lower.contains("account successfully checked out")
+        && !lower.contains("tapez h pour")
+        && !lower.contains("type h for")
 }
 
 #[cfg(unix)]
@@ -402,7 +531,8 @@ fn contains_ssh_auth_prompt(buffer: &str) -> bool {
 
 #[cfg(unix)]
 fn contains_wallix_prompt(buffer: &str) -> bool {
-    let trimmed = buffer.trim_end();
+    let clean = crate::wallix::strip_ansi(buffer);
+    let trimmed = clean.trim_end();
     trimmed.ends_with(" >")
         || trimmed.ends_with(">")
         || trimmed.lines().rev().find(|line| !line.trim().is_empty()) == Some(">")
@@ -410,7 +540,8 @@ fn contains_wallix_prompt(buffer: &str) -> bool {
 
 #[cfg(unix)]
 fn contains_wallix_target_address_prompt(buffer: &str) -> bool {
-    let lowered = buffer.to_ascii_lowercase();
+    let clean = crate::wallix::strip_ansi(buffer);
+    let lowered = clean.to_ascii_lowercase();
     lowered.contains("adresse cible")
         || lowered.contains("target address")
         || lowered.contains("destination address")
@@ -418,7 +549,8 @@ fn contains_wallix_target_address_prompt(buffer: &str) -> bool {
 
 #[cfg(unix)]
 fn contains_wallix_return_selector_prompt(buffer: &str) -> bool {
-    let lowered = buffer.to_lowercase();
+    let clean = crate::wallix::strip_ansi(buffer);
+    let lowered = clean.to_lowercase();
     lowered.contains("retour au sélecteur")
         || lowered.contains("retour au selecteur")
         || lowered.contains("return to selector")
@@ -426,7 +558,8 @@ fn contains_wallix_return_selector_prompt(buffer: &str) -> bool {
 
 #[cfg(unix)]
 fn parse_wallix_page_position(buffer: &str) -> Option<(u32, u32)> {
-    let lowered = buffer.to_ascii_lowercase();
+    let clean = crate::wallix::strip_ansi(buffer);
+    let lowered = clean.to_ascii_lowercase();
     let marker = "page ";
     let start = lowered.rfind(marker)? + marker.len();
     let tail = &lowered[start..];
@@ -489,67 +622,6 @@ fn spawn_wallix_pty(args: &[String]) -> Result<(nix::unistd::Pid, std::fs::File,
             Ok((child, master_reader, master_writer))
         }
     }
-}
-
-#[cfg(unix)]
-#[allow(dead_code)]
-fn read_until_wallix_prompt(master_reader: &mut std::fs::File) -> Result<String> {
-    let mut transcript = String::new();
-    loop {
-        let mut buf = [0_u8; 4096];
-        let read = master_reader.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-
-        let chunk = String::from_utf8_lossy(&buf[..read]);
-        transcript.push_str(&chunk);
-        if transcript.len() > 64 * 1024 {
-            let drain = transcript.len().saturating_sub(64 * 1024);
-            transcript.drain(..drain);
-        }
-
-        if contains_wallix_prompt(&transcript) {
-            return Ok(transcript);
-        }
-    }
-
-    Err(anyhow::anyhow!(
-        "Wallix session exited before the selection prompt was displayed"
-    ))
-}
-
-/// Variante de [`read_until_wallix_prompt`] qui s'arrête aussi sur un prompt d'auth SSH.
-/// Retourne un résultat préfixé par `"SSH_AUTH_REQUIRED:"` si un tel prompt est détecté.
-#[cfg(unix)]
-fn read_until_wallix_prompt_or_auth(master_reader: &mut std::fs::File) -> Result<String> {
-    let mut transcript = String::new();
-    loop {
-        let mut buf = [0_u8; 4096];
-        let read = master_reader.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-
-        let chunk = String::from_utf8_lossy(&buf[..read]);
-        transcript.push_str(&chunk);
-        if transcript.len() > 64 * 1024 {
-            let drain = transcript.len().saturating_sub(64 * 1024);
-            transcript.drain(..drain);
-        }
-
-        if contains_wallix_prompt(&transcript) {
-            return Ok(transcript);
-        }
-
-        if contains_ssh_auth_prompt(&transcript) {
-            return Ok(format!("SSH_AUTH_REQUIRED:{transcript}"));
-        }
-    }
-
-    Err(anyhow::anyhow!(
-        "Wallix session exited before the selection prompt was displayed"
-    ))
 }
 
 #[cfg(unix)]
@@ -632,10 +704,12 @@ fn connect_wallix_via_pty_with_selection(
                 // et l'output est affiché ci-dessous pour que l'utilisateur voit le prompt.
             }
 
-            // En mode auto-sélection, on n'affiche rien tant que la phase menu
-            // n'est pas terminée afin d'éviter le bruit du menu global.
+            // En mode auto-sélection, on n'affiche rien tant que la sélection n'est pas
+            // envoyée afin d'éviter le bruit du menu global. Dès que selection_completed,
+            // on affiche tout — le password prompt peut arriver sans "Adresse cible" selon
+            // la config Wallix.
             // Exception : toujours montrer les prompts d'auth sans credential connu.
-            if !hide_menu_output || target_address_sent || (auth_prompted && auth.is_none()) {
+            if !hide_menu_output || selection_completed || (auth_prompted && auth.is_none()) {
                 stdout.write_all(&buf[..read])?;
                 stdout.flush()?;
             }
@@ -798,6 +872,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
         }
     }
 
@@ -985,7 +1061,11 @@ mod tests {
         let args = build_wallix_bastion_args(&s, false).unwrap();
 
         assert!(args.contains(&"-l".to_string()));
-        assert!(args.contains(&"demo_user".to_string()));
+        // Login includes target host for server-side Wallix filtering (avoids paginating all entries).
+        assert!(
+            args.iter()
+                .any(|a| a.starts_with("demo_user@") && a.contains(":SSH:demo_user"))
+        );
         assert!(args.contains(&"-p".to_string()));
         assert!(args.contains(&"8022".to_string()));
         assert_eq!(args.last().unwrap(), "bastion.example.com");

--- a/src/ssh/sftp.rs
+++ b/src/ssh/sftp.rs
@@ -640,6 +640,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
         }
     }
 }

--- a/src/ssh/tunnel.rs
+++ b/src/ssh/tunnel.rs
@@ -221,6 +221,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
         }
     }
 

--- a/src/wallix/mod.rs
+++ b/src/wallix/mod.rs
@@ -140,9 +140,10 @@ pub fn build_expected_targets(server: &ResolvedServer) -> Vec<String> {
 ///
 /// This function extracts the ID, target (Cible), and group (Autorisation) columns.
 pub fn parse_wallix_menu(output: &str) -> Result<Vec<WallixMenuEntry>> {
+    let cleaned = strip_ansi(output);
     let mut entries = Vec::new();
 
-    for line in output.lines() {
+    for line in cleaned.lines() {
         let trimmed = line.trim();
 
         // Ignore headers, separators and empty lines.
@@ -152,13 +153,13 @@ pub fn parse_wallix_menu(output: &str) -> Result<Vec<WallixMenuEntry>> {
             || trimmed.contains("Autorisation")
             || trimmed
                 .chars()
-                .all(|c| matches!(c, '─' | '┼' | '│' | '-' | '+'))
+                .all(|c| matches!(c, '\u{2500}' | '\u{253C}' | '\u{2502}' | '-' | '+'))
         {
             continue;
         }
 
-        let separator = if trimmed.contains('│') {
-            '│'
+        let separator = if trimmed.contains('\u{2502}') {
+            '\u{2502}'
         } else if trimmed.contains('|') {
             '|'
         } else {
@@ -197,6 +198,37 @@ pub fn parse_wallix_menu(output: &str) -> Result<Vec<WallixMenuEntry>> {
     }
 
     Ok(entries)
+}
+
+/// Strip ANSI/VT100 escape sequences from a string.
+pub(crate) fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    // consume until a letter (the final byte of a CSI sequence)
+                    for c in chars.by_ref() {
+                        if c.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                }
+                Some('(') | Some(')') | Some('*') | Some('+') => {
+                    chars.next();
+                    chars.next(); // consume one more designator byte
+                }
+                _ => {
+                    chars.next(); // consume whatever follows ESC
+                }
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 /// Select a menu entry ID based on target and group matching.
@@ -272,12 +304,15 @@ fn normalize_authorization_segment(value: &str) -> String {
 }
 
 pub fn build_expected_groups(server: &ResolvedServer) -> Result<Vec<String>> {
-    let configured_group = server.wallix_group.as_deref().ok_or_else(|| {
-        anyhow!(
-            "wallix.group is not configured for server '{}'",
-            server.name
-        )
-    })?;
+    let configured_group = match server
+        .wallix_group
+        .as_deref()
+        .map(str::trim)
+        .filter(|g| !g.is_empty())
+    {
+        Some(g) => g,
+        None => return Ok(vec![]),
+    };
 
     let mut candidates = vec![configured_group.to_string()];
 
@@ -318,12 +353,11 @@ pub fn select_id_for_server(
 ) -> Result<String> {
     let targets = build_expected_targets(server);
     let groups = build_expected_groups(server)?;
-    let configured_group = server.wallix_group.as_deref().ok_or_else(|| {
-        anyhow!(
-            "wallix.group is not configured for server '{}'",
-            server.name
-        )
-    })?;
+    let configured_group = server
+        .wallix_group
+        .as_deref()
+        .map(str::trim)
+        .filter(|g| !g.is_empty());
 
     let mut had_target_match = false;
     let mut available_groups_for_matching_targets: Vec<String> = Vec::new();
@@ -342,6 +376,20 @@ pub fn select_id_for_server(
         for entry in &target_entries {
             if !available_groups_for_matching_targets.contains(&entry.group) {
                 available_groups_for_matching_targets.push(entry.group.clone());
+            }
+        }
+
+        // No group configured: auto-select only if exactly one entry matches the target.
+        if configured_group.is_none() {
+            match target_entries.len() {
+                1 => return Ok(target_entries[0].id.clone()),
+                _ => {
+                    return Err(anyhow!(
+                        "Multiple menu entries found for target '{}'. Configure wallix.group to auto-select. Available groups: {}",
+                        target,
+                        available_groups_for_matching_targets.join(", ")
+                    ));
+                }
             }
         }
 
@@ -364,9 +412,10 @@ pub fn select_id_for_server(
             }
         }
 
+        let cg = configured_group.unwrap_or_default();
         let suffix_matches: Vec<_> = target_entries
             .iter()
-            .filter(|entry| group_suffix_matches(&entry.group, configured_group))
+            .filter(|entry| group_suffix_matches(&entry.group, cg))
             .collect();
         match suffix_matches.len() {
             1 => return Ok(suffix_matches[0].id.clone()),
@@ -375,7 +424,7 @@ pub fn select_id_for_server(
                     "Multiple menu entries ({}) found for target '{}' matching group suffix '{}'. Cannot auto-select.",
                     n,
                     target,
-                    configured_group
+                    cg
                 ));
             }
             _ => {}
@@ -385,7 +434,7 @@ pub fn select_id_for_server(
     if had_target_match {
         return Err(anyhow!(
             "No menu entry found for matching targets with group '{}'. Available groups for these targets: {}",
-            configured_group,
+            configured_group.unwrap_or("(none)"),
             available_groups_for_matching_targets.join(", ")
         ));
     }
@@ -407,6 +456,38 @@ pub fn select_id_for_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_strip_ansi_removes_csi_sequences() {
+        // CSI clear screen + cursor home
+        assert_eq!(
+            strip_ansi("\x1b[2J\x1b[H| 0 | target | group |"),
+            "| 0 | target | group |"
+        );
+    }
+
+    #[test]
+    fn test_strip_ansi_removes_color_codes() {
+        assert_eq!(strip_ansi("\x1b[1;32mhello\x1b[0m"), "hello");
+    }
+
+    #[test]
+    fn test_strip_ansi_passthrough_plain_text() {
+        let s = "| 42 | pcollin@default@HOST:SSH | GROUP_ces3s-admins |";
+        assert_eq!(strip_ansi(s), s);
+    }
+
+    #[test]
+    fn test_parse_wallix_menu_with_ansi_codes() {
+        let output = "\x1b[2J\x1b[H| ID | Cible (page 1/1)   | Autorisation\n\
+                      |----|--------------------|-----------\n\
+                      |  0 | demo@default@HOST:SSH | STI-GROUP_ces3s-admins |\n\
+                      \x1b[1m > \x1b[0m";
+        let entries = parse_wallix_menu(output).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "0");
+        assert_eq!(entries[0].group, "STI-GROUP_ces3s-admins");
+    }
 
     #[test]
     fn test_group_suffix_matches_short_group() {
@@ -595,6 +676,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -643,6 +726,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -660,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_id_for_server_requires_group() {
+    fn test_select_id_for_server_single_entry_no_group() {
         let entries = vec![WallixMenuEntry {
             id: "0".to_string(),
             target: "demo_user@default@APP-ALPHA-BD:SSH".to_string(),
@@ -688,6 +773,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -701,8 +788,66 @@ mod tests {
             hook_timeout_secs: 5,
         };
 
+        // Single entry matching the target → auto-selected even without wallix_group.
+        let id = select_id_for_server(&entries, &server).unwrap();
+        assert_eq!(id, "0");
+    }
+
+    #[test]
+    fn test_select_id_for_server_multi_entry_no_group_returns_error() {
+        let entries = vec![
+            WallixMenuEntry {
+                id: "0".to_string(),
+                target: "demo_user@default@APP-ALPHA-BD:SSH".to_string(),
+                group: "APP-ALPHA_ops-admins".to_string(),
+            },
+            WallixMenuEntry {
+                id: "1".to_string(),
+                target: "demo_user@default@APP-ALPHA-BD:SSH".to_string(),
+                group: "APP-ALPHA_dev-admins".to_string(),
+            },
+        ];
+
+        let server = ResolvedServer {
+            namespace: String::new(),
+            group_name: String::new(),
+            env_name: String::new(),
+            name: "app-alpha-ambiguous".to_string(),
+            host: "APP-ALPHA-BD".to_string(),
+            user: "demo_user".to_string(),
+            port: 22,
+            ssh_key: String::new(),
+            ssh_options: vec![],
+            default_mode: crate::config::ConnectionMode::Wallix,
+            jump_host: None,
+            bastion_host: Some("bastion.example.test".to_string()),
+            bastion_user: Some("demo_user".to_string()),
+            bastion_template: "{target_user}@%n:SSH:{bastion_user}".to_string(),
+            wallix_group: None,
+            wallix_account: "default".to_string(),
+            wallix_protocol: "SSH".to_string(),
+            wallix_auto_select: true,
+            wallix_fail_if_menu_match_error: true,
+            wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
+            use_system_ssh_config: false,
+            probe_filesystems: vec![],
+            tunnels: vec![],
+            tags: vec![],
+            control_master: false,
+            agent_forwarding: false,
+            control_path: String::new(),
+            control_persist: "10m".to_string(),
+            pre_connect_hook: None,
+            post_disconnect_hook: None,
+            hook_timeout_secs: 5,
+        };
+
+        // Multiple entries with no group configured → error prompting user to set wallix.group.
         let error = select_id_for_server(&entries, &server).unwrap_err();
-        assert!(error.to_string().contains("wallix.group is not configured"));
+        assert!(error.to_string().contains("Multiple menu entries"));
+        assert!(error.to_string().contains("wallix.group"));
     }
 
     #[test]
@@ -728,6 +873,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -771,6 +918,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -819,6 +968,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -864,6 +1015,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],
@@ -909,6 +1062,8 @@ mod tests {
             wallix_auto_select: true,
             wallix_fail_if_menu_match_error: true,
             wallix_selection_timeout_secs: 8,
+            wallix_direct: false,
+            wallix_authorization: None,
             use_system_ssh_config: false,
             probe_filesystems: vec![],
             tunnels: vec![],

--- a/tests/sftp_transfer.rs
+++ b/tests/sftp_transfer.rs
@@ -40,6 +40,8 @@ fn test_server() -> ResolvedServer {
         wallix_auto_select: true,
         wallix_fail_if_menu_match_error: true,
         wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
     }
 }
 

--- a/tests/ssh_args.rs
+++ b/tests/ssh_args.rs
@@ -42,6 +42,8 @@ fn base_server() -> ResolvedServer {
         wallix_auto_select: true,
         wallix_fail_if_menu_match_error: true,
         wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
     }
 }
 

--- a/tests/tunnel_handle.rs
+++ b/tests/tunnel_handle.rs
@@ -43,6 +43,8 @@ fn base_server() -> ResolvedServer {
         wallix_auto_select: true,
         wallix_fail_if_menu_match_error: true,
         wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
     }
 }
 

--- a/tests/wallix_menu.rs
+++ b/tests/wallix_menu.rs
@@ -23,6 +23,8 @@ fn wallix_server(group: Option<&str>) -> ResolvedServer {
         wallix_auto_select: true,
         wallix_fail_if_menu_match_error: true,
         wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
         use_system_ssh_config: false,
         probe_filesystems: vec![],
         tunnels: vec![],
@@ -68,7 +70,7 @@ Tapez h pour l'aide, ctrl-D pour quitter
 }
 
 #[test]
-fn errors_when_group_is_missing_from_server_config() {
+fn selects_single_entry_when_group_is_missing_from_server_config() {
     let output = r#"
 | ID | Cible (page 1/1)               | Autorisation
 |----|--------------------------------|-----------------------
@@ -77,7 +79,23 @@ fn errors_when_group_is_missing_from_server_config() {
 
     let entries = parse_wallix_menu(output).unwrap();
     let server = wallix_server(None);
-    let error = select_id_for_server(&entries, &server).unwrap_err();
+    // Single matching entry → auto-selected even without wallix_group configured.
+    let id = select_id_for_server(&entries, &server).unwrap();
+    assert_eq!(id, "0");
+}
 
-    assert!(error.to_string().contains("wallix.group is not configured"));
+#[test]
+fn errors_when_group_is_missing_and_multiple_entries_match() {
+    let output = r#"
+| ID | Cible (page 1/1)               | Autorisation
+|----|--------------------------------|-----------------------
+|  0 | demo_user@default@APP-ALPHA-BD:SSH | APP-ALPHA_ops-admins
+|  1 | demo_user@default@APP-ALPHA-BD:SSH | APP-ALPHA_dev-admins
+"#;
+
+    let entries = parse_wallix_menu(output).unwrap();
+    let server = wallix_server(None);
+    let error = select_id_for_server(&entries, &server).unwrap_err();
+    assert!(error.to_string().contains("Multiple menu entries"));
+    assert!(error.to_string().contains("wallix.group"));
 }


### PR DESCRIPTION
## Summary

- **ANSI parsing fix**: strip VT100 escape codes before menu parsing and prompt detection — fixes "no valid menu entries found" on servers with decorated terminal output
- **Server-side filtering**: use filtered login format (`bastion_user@host:protocol:bastion_user`) to reduce a 27-page menu to 1-2 entries without client-side pagination
- **Direct connection detection**: detect Wallix direct checkout via "account successfully checked out" and short-circuit the PTY flow with a `WALLIX_DIRECT_CONNECTION` sentinel
- **`wallix.direct`**: new config flag to bypass the menu probe entirely for known direct-checkout targets (~5 s → instant)
- **`wallix.authorization`**: new config flag to pin an exact Wallix authorization name (e.g. `STI-ANSCORE_ces3s-admins`), taking priority over `wallix.group` — solves multi-group ambiguity without manual menu selection
- **PTY display fix**: key terminal passthrough on `selection_completed` instead of `target_address_sent` to prevent invisible password prompts
- **Debug tooling**: `SUSSHI_WALLIX_DEBUG=1` dumps the full PTY transcript to `/tmp/susshi-wallix-debug.txt`

## Test plan

- [ ] Existing test suite passes (`cargo test`)
- [ ] `cargo clippy` clean, `cargo fmt` applied
- [ ] Wallix server with 27-page menu connects without full pagination
- [ ] Server with multiple authorizations: `wallix.authorization` pins the correct one, no menu shown
- [ ] `wallix.direct: true` on known direct-checkout server connects instantly
- [ ] Server without `direct`/`authorization` still auto-selects or falls back to popup correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)