### PR TITLE
ci: add CODECOV_TOKEN to coverage upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary

- Add `token: ${{ secrets.CODECOV_TOKEN }}` to the Codecov upload step — required for the upload to be attributed to the correct repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)