### PR TITLE
fix: catch known_host errors and inject StrictHostKeyChecking=accept-new

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,15 +33,16 @@ Stack : Rust, Ratatui, YAML, SSH2, Catppuccin
 
 ## 🟢 Long terme / nouvelles fonctionnalités
 
-### TUI
-- Ajouter une aide interactive `(h)` pour le détail des options
-- Dashboard "overview" : état santé de tous les serveurs d'un groupe en parallèle
-- Historique des commandes ad-hoc (flèche haut/bas)
-- Mode split pane pour surveiller deux serveurs côte à côte
-
 ### Connectivité
 - Reconnexion automatique avec backoff en mode `keep_open`
 - Multiplexage ControlMaster avec affichage des sessions actives
+- Gestion des password
+  si vous n'avez pas de clé ssh enregistré sur le bastion phm la connexion est impossible
+  pour l'instant je gère mal (quand c'est le cas) le fallback password
+  je n'ai pas test non plus une clé ssh avec password
+  et les messages de clé (known_host) cassent la TUI
+  il faut implémenter un prompt password en cas de besoin de la connexion ssh
+
 
 ### Inventaire & intégration
 - Exécution en masse sur un groupe (`susshi exec --group prod "uptime"`)
@@ -52,4 +53,6 @@ Stack : Rust, Ratatui, YAML, SSH2, Catppuccin
 ### Sécurité
 - Intégration SSH agent (détection automatique des identités)
 - Audit log local des connexions (timestamp, durée, code de sortie)
-- Chiffrement des secrets via keyring OS (`secret-service`)
+
+### Packaging
+- Ajouter dans les paquets linux une manpage et un exemple de la configuration dans `/usr/share/doc/susshi`

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -226,7 +226,24 @@ pub fn probe(server: &ResolvedServer, mode: ConnectionMode) -> Result<ProbeResul
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("SSH probe échoué : {}", stderr.trim());
+        let stderr = stderr.trim();
+        // Produire des messages lisibles pour les erreurs known_host courantes.
+        if stderr.contains("REMOTE HOST IDENTIFICATION HAS CHANGED") {
+            anyhow::bail!(
+                "La clé SSH de cet hôte a changé.\n\
+                 Supprimez l'ancienne entrée avec :\n\
+                 ssh-keygen -R {}",
+                server.host
+            );
+        }
+        if stderr.contains("Host key verification failed") {
+            anyhow::bail!(
+                "Vérification de la clé SSH échouée pour {}.\n\
+                 Vérifiez ~/.ssh/known_hosts.",
+                server.host
+            );
+        }
+        anyhow::bail!("SSH probe échoué : {}", stderr);
     }
 
     ProbeResult::parse(

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -101,6 +101,20 @@ pub fn build_ssh_args(
         }
     }
 
+    // Quand on ignore le ssh_config système (-F /dev/null) et que l'utilisateur
+    // n'a pas explicitement configuré StrictHostKeyChecking, on injecte
+    // accept-new : les nouveaux hôtes sont acceptés silencieusement, mais une
+    // clé modifiée reste bloquante (comportement safe par défaut).
+    if !server.use_system_ssh_config
+        && !server
+            .ssh_options
+            .iter()
+            .any(|o| o.to_ascii_lowercase().contains("stricthostkeychecking"))
+    {
+        args.push("-o".into());
+        args.push("StrictHostKeyChecking=accept-new".into());
+    }
+
     if server.agent_forwarding {
         args.push("-A".into());
     }
@@ -455,6 +469,16 @@ fn build_wallix_bastion_args(server: &ResolvedServer, verbose: bool) -> Result<V
             args.push("-o".into());
             args.push(opt.clone());
         }
+    }
+
+    if !server.use_system_ssh_config
+        && !server
+            .ssh_options
+            .iter()
+            .any(|o| o.to_ascii_lowercase().contains("stricthostkeychecking"))
+    {
+        args.push("-o".into());
+        args.push("StrictHostKeyChecking=accept-new".into());
     }
 
     let bastion_host_str = server.bastion_host.as_deref().unwrap_or("");
@@ -1125,5 +1149,66 @@ mod tests {
         let s3 = base_server();
         let args3 = build_ssh_args(&s3, ConnectionMode::Direct, false).unwrap();
         assert_eq!(args3.last().unwrap(), "admin@198.51.100.1");
+    }
+
+    // ── StrictHostKeyChecking=accept-new ──────────────────────────────────────
+
+    #[test]
+    fn accept_new_injected_when_no_strict_host_option() {
+        let s = base_server(); // use_system_ssh_config=false, ssh_options=[]
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        let idx = args.iter().position(|a| a == "-o").unwrap();
+        // Cherche accept-new parmi toutes les valeurs -o
+        let has_accept_new = args
+            .windows(2)
+            .any(|w| w[0] == "-o" && w[1] == "StrictHostKeyChecking=accept-new");
+        assert!(has_accept_new, "accept-new doit être injecté: {args:?}");
+        // La destination reste dernière malgré l'injection
+        assert_eq!(args.last().unwrap(), "admin@198.51.100.1");
+        let _ = idx;
+    }
+
+    #[test]
+    fn accept_new_not_injected_when_user_sets_strict_host_no() {
+        let mut s = base_server();
+        s.ssh_options = vec!["StrictHostKeyChecking=no".into()];
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        let count = args
+            .windows(2)
+            .filter(|w| w[0] == "-o" && w[1].to_ascii_lowercase().contains("stricthostkeychecking"))
+            .count();
+        assert_eq!(
+            count, 1,
+            "une seule option StrictHostKeyChecking attendue: {args:?}"
+        );
+    }
+
+    #[test]
+    fn accept_new_not_injected_when_use_system_ssh_config() {
+        let mut s = base_server();
+        s.use_system_ssh_config = true;
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        let has_accept_new = args
+            .windows(2)
+            .any(|w| w[0] == "-o" && w[1] == "StrictHostKeyChecking=accept-new");
+        assert!(
+            !has_accept_new,
+            "ne doit pas injecter avec use_system_ssh_config: {args:?}"
+        );
+    }
+
+    #[test]
+    fn accept_new_injected_for_wallix_bastion_args() {
+        let mut s = base_server();
+        s.bastion_host = Some("bastion.example.com".into());
+        s.bastion_user = Some("buser".into());
+        let args = build_wallix_bastion_args(&s, false).unwrap();
+        let has_accept_new = args
+            .windows(2)
+            .any(|w| w[0] == "-o" && w[1] == "StrictHostKeyChecking=accept-new");
+        assert!(
+            has_accept_new,
+            "accept-new doit être injecté pour Wallix: {args:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Inject `StrictHostKeyChecking=accept-new` in `build_ssh_args()` and `build_wallix_bastion_args()` when `use_system_ssh_config=false` and no explicit option is set — new hosts are accepted silently, changed keys are blocked
- Pattern-match SSH stderr in `probe()` to surface actionable messages for `REMOTE HOST IDENTIFICATION HAS CHANGED` and `Host key verification failed`, instead of raw SSH output that could break the TUI
- 4 new unit tests covering the injection logic

## Test plan

- [ ] New host: TUI connects without any prompt
- [ ] Changed host key: probe shows a clear message with `ssh-keygen -R <host>` command
- [ ] `StrictHostKeyChecking=no` in `ssh_options`: injection skipped, user option respected
- [ ] `use_system_ssh_config: true`: injection skipped, system config takes over
- [ ] All 184 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)