### PR TITLE
chore: release v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.4] — 2026-05-19
+
+### Added
+
+- Reconnexion automatique avec backoff et affichage ControlMaster
+
+
 ## [0.15.3] — 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "susshi"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.15.3 -> 0.15.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.4] — 2026-05-19

### Added

- Reconnexion automatique avec backoff et affichage ControlMaster
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).