### PR TITLE
chore: release v0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.6] — 2026-05-19
+
+### Changed
+
+- Regrouper les 19 paramètres de resolve_server dans ServerDefaults<'a>
+
+- Amélioration robustesse et performance — extend O(n²)→HashSet, unwrap, hooks label
+
+
 ## [0.15.5] — 2026-05-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.15.5 -> 0.15.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.6] — 2026-05-19

### Changed

- Regrouper les 19 paramètres de resolve_server dans ServerDefaults<'a>

- Amélioration robustesse et performance — extend O(n²)→HashSet, unwrap, hooks label
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).