### PR TITLE
chore: release v0.15.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.15.7"
+version = "0.15.8"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.15.7 -> 0.15.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.7] — 2026-05-20

### Added

- Recherche floue (fuzzy search) via skim matcher

- Manpage générée + doc dans les paquets DEB/RPM

- Toggle capture souris (M) + i18n overlay aide

- Wallix — header_columns personnalisables pour le parsing menu

- Ajouter export OpenSSH config (--export openssh)

- Ajouter export CSV (--export csv)

- Ajouter ssh_agent_sock par serveur — agent SSH dédié par cible

- Support du champ ssh_cert par serveur

- Toggle thème Catppuccin à la volée (Ctrl+Y)

- Ajouter le champ notes par serveur

- Fallback clipboard — overlay si arboard est indisponible

- Persister l'historique des commandes ad-hoc entre les sessions

- Afficher le raccourci E (expand-all) dans la barre d'aide et la popup h

- Ajouter raccourci E pour déplier tous les groupes


### Fixed

- Corriger clippy unnecessary_sort_by + manpage/doc dans PKGBUILD

- Corriger test ssh_agent_sock — chercher IdentityAgent avec windows(2)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).