### PR TITLE
fix: corriger PKGBUILD.bin (chemins docs) et update-pkgbuild.sh

### DIFF
--- a/PKGBUILD.bin
+++ b/PKGBUILD.bin
@@ -17,6 +17,6 @@ package() {
     install -Dm0755 "susshi-${pkgver}-linux-amd64" "$pkgdir/usr/bin/susshi"
     install -Dm0644 "susshi-${pkgver}/LICENCE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -Dm0644 "susshi-${pkgver}/README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
-    find "susshi-${pkgver}/docs/" -type f -exec install -Dm0644 {} "$pkgdir/usr/share/doc/$pkgname/docs/{}" \;
-    find "susshi-${pkgver}/examples/" -type f -exec install -Dm0644 {} "$pkgdir/usr/share/doc/$pkgname/examples/{}" \;
+    (cd "susshi-${pkgver}" && find docs/ -type f -exec install -Dm0644 {} "$pkgdir/usr/share/doc/$pkgname/{}" \;)
+    (cd "susshi-${pkgver}" && find examples/ -type f -exec install -Dm0644 {} "$pkgdir/usr/share/doc/$pkgname/{}" \;)
 }

--- a/scripts/update-pkgbuild.sh
+++ b/scripts/update-pkgbuild.sh
@@ -14,4 +14,15 @@ sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
 sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 sed -i "s/^b2sums=(.*/b2sums=(${B2SUM})/" PKGBUILD
 
-echo "Done: pkgver=${VERSION}, b2sums=${B2SUM}"
+echo "Updating PKGBUILD.bin to ${TAG}..."
+
+curl -fsSL "https://github.com/yatoub/susshi/releases/download/${TAG}/susshi-linux-amd64" \
+    -o /tmp/susshi-linux-amd64
+B2SUM_BIN=$(b2sum /tmp/susshi-linux-amd64 | cut -d' ' -f1)
+
+sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD.bin
+sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD.bin
+sed -i "s/^b2sums=(.*/b2sums=('${B2SUM}')/" PKGBUILD.bin
+sed -i "s/^b2sums_x86_64=(.*/b2sums_x86_64=('${B2SUM_BIN}')/" PKGBUILD.bin
+
+echo "Done: pkgver=${VERSION}, b2sums=${B2SUM}, b2sums_x86_64=${B2SUM_BIN}"


### PR DESCRIPTION
## Summary

- **PKGBUILD.bin** : les `find` sans `cd` préalable produisaient des chemins préfixés (`susshi-${pkgver}/docs/file`) dans la destination, créant une arborescence incorrecte sous `$pkgdir`. Corrigé en utilisant un sous-shell `(cd "susshi-${pkgver}" && find docs/ ...)` comme dans `PKGBUILD`.
- **scripts/update-pkgbuild.sh** : le script ne mettait pas à jour `PKGBUILD.bin`. Il télécharge maintenant le binaire précompilé depuis la release GitHub pour calculer `b2sums_x86_64` et met à jour `pkgver`, `pkgrel`, `b2sums` et `b2sums_x86_64` dans `PKGBUILD.bin`.

## Test plan

- [ ] Vérifier que `makepkg` sur `PKGBUILD.bin` installe les docs sous `usr/share/doc/susshi-bin/docs/` (sans le préfixe `susshi-${pkgver}/`)
- [ ] Lancer `scripts/update-pkgbuild.sh` et vérifier que `PKGBUILD.bin` est bien mis à jour avec les bons checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)