### PR TITLE
chore: release v0.15.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.9] — 2026-05-24
+
+### Fixed
+
+- Corriger chemins docs/examples dans PKGBUILD.bin + update-pkgbuild.sh
+
+
 ## [0.15.7] — 2026-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.15.8"
+version = "0.15.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.15.8"
+version = "0.15.9"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.15.8 -> 0.15.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.9] — 2026-05-24

### Fixed

- Corriger chemins docs/examples dans PKGBUILD.bin + update-pkgbuild.sh
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).