### PR TITLE
chore: release v0.15.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.15.15"
+version = "0.15.16"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.15.15"
+version = "0.15.16"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.15.15 -> 0.15.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.12] — 2026-05-27

### Fixed

- Tag inheritance across hierarchy + 25 new tests + doc schema
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).