### PR TITLE
feat(security): harden YAML/HTTP + test coverage 86% + CI cleanup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[alias]
+# Run coverage excluding non-testable files (UI rendering, binary entry point, i18n strings).
+# Usage: cargo cov              → summary only
+#        cargo cov --html       → HTML report in target/llvm-cov/html/
+cov = "llvm-cov --ignore-filename-regex 'src/(ui/|main\\.rs|i18n\\.rs)' --summary-only"

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,5 +1,12 @@
 name: Publish to AUR
 
+# Triggered automatically after the Release workflow succeeds,
+# or manually via workflow_dispatch to re-publish an existing tag.
+#
+# Updates two AUR packages in parallel:
+#   susshi      — builds from the released source tarball
+#   susshi-bin  — installs the pre-built susshi-linux-x86_64 binary
+
 on:
   workflow_run:
     workflows: ["Release"]
@@ -11,29 +18,25 @@ on:
         required: true
 
 jobs:
-  aur-publish:
-    name: Publish to AUR
+  # ── susshi (source package) ───────────────────────────────────────────────
+
+  aur-source:
+    name: Publish susshi (source)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # For workflow_run: only proceed if the Release workflow succeeded.
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - name: Resolve tag
-        id: resolve
+      - name: Resolve version to publish
+        id: ver
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          else
-            TAG="$RUN_HEAD_BRANCH"
-          fi
-          # Validate: must look like a semver tag (vX.Y.Z)
+          TAG="${INPUT_TAG:-$RUN_HEAD_BRANCH}"
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
             echo "Invalid tag format: $TAG" >&2
             exit 1
@@ -41,27 +44,27 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Compute b2sum of release archive
-        id: b2sum
+      - name: Compute checksum of source archive
+        id: checksum
         env:
-          TAG: ${{ steps.resolve.outputs.tag }}
+          TAG: ${{ steps.ver.outputs.tag }}
         run: |
           curl -fsSL "https://github.com/yatoub/susshi/archive/refs/tags/${TAG}.tar.gz" -o archive.tar.gz
-          echo "sum=$(b2sum archive.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "b2sum=$(b2sum archive.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
-      - name: Update PKGBUILD
+      - name: Patch PKGBUILD
         env:
-          VERSION: ${{ steps.resolve.outputs.version }}
-          B2SUM: ${{ steps.b2sum.outputs.sum }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          B2SUM: ${{ steps.checksum.outputs.b2sum }}
         run: |
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
           sed -i "s/^b2sums=(.*/b2sums=(${B2SUM})/" PKGBUILD
 
-      - name: Publish to AUR
+      - name: Push to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: susshi
@@ -69,12 +72,14 @@ jobs:
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "chore: update to ${{ steps.resolve.outputs.tag }}"
+          commit_message: "chore: update to ${{ steps.ver.outputs.tag }}"
           ssh_keyscan_types: rsa,ecdsa,ed25519
           allow_empty_commits: false
 
-  aur-publish-bin:
-    name: Publish susshi-bin to AUR
+  # ── susshi-bin (pre-built binary package) ─────────────────────────────────
+
+  aur-bin:
+    name: Publish susshi-bin (pre-built)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,18 +88,13 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - name: Resolve tag
+      - name: Resolve version to publish
         id: ver
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          else
-            TAG="$RUN_HEAD_BRANCH"
-          fi
-          # Validate: must look like a semver tag (vX.Y.Z)
+          TAG="${INPUT_TAG:-$RUN_HEAD_BRANCH}"
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
             echo "Invalid tag format: $TAG" >&2
             exit 1
@@ -102,25 +102,24 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Compute b2sums for susshi-bin
-        id: b2sums
+      - name: Compute checksums (source archive + Linux binary)
+        id: checksums
         env:
           TAG: ${{ steps.ver.outputs.tag }}
         run: |
           curl -fsSL "https://github.com/yatoub/susshi/archive/refs/tags/${TAG}.tar.gz" -o archive.tar.gz
-          curl -fsSL "https://github.com/yatoub/susshi/releases/download/${TAG}/susshi-linux-amd64" -o susshi-linux-amd64
+          curl -fsSL "https://github.com/yatoub/susshi/releases/download/${TAG}/susshi-linux-x86_64" -o susshi-linux-x86_64
           echo "src=$(b2sum archive.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          echo "bin=$(b2sum susshi-linux-amd64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "bin=$(b2sum susshi-linux-x86_64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
-      - name: Update PKGBUILD.bin
+      - name: Patch PKGBUILD.bin
         env:
-          TAG: ${{ steps.ver.outputs.tag }}
           VERSION: ${{ steps.ver.outputs.version }}
-          B2SUM_SRC: ${{ steps.b2sums.outputs.src }}
-          B2SUM_BIN: ${{ steps.b2sums.outputs.bin }}
+          B2SUM_SRC: ${{ steps.checksums.outputs.src }}
+          B2SUM_BIN: ${{ steps.checksums.outputs.bin }}
         run: |
           cp PKGBUILD.bin PKGBUILD
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
@@ -128,7 +127,7 @@ jobs:
           sed -i "s/^b2sums=(.*/b2sums=(${B2SUM_SRC})/" PKGBUILD
           sed -i "s/^b2sums_x86_64=(.*/b2sums_x86_64=(${B2SUM_BIN})/" PKGBUILD
 
-      - name: Publish susshi-bin to AUR
+      - name: Push to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: susshi-bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,35 @@
-name: "CI"
+name: CI
 
 on:
   push:
-    branches: ["master"]
+    branches: [master]
   pull_request:
-    branches: ["master"]
+    branches: [master]
+
+# Cancel any in-progress run for the same branch when a new push arrives.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test Suite
+  # ── 1. Quality gate ───────────────────────────────────────────────────────
+  #
+  #  lint → test → coverage
+  #              → cross-platform builds
+  #
+  # audit and megalinter run independently (orthogonal signal).
+  # ─────────────────────────────────────────────────────────────────────────
+
+  lint:
+    name: Lint (fmt + clippy)
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
@@ -30,19 +43,78 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Lint with Clippy
+      - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: [lint]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --verbose
 
-  coverage:
-    name: Test Coverage
+  # ── 2. Security (independent) ─────────────────────────────────────────────
+
+  audit:
+    name: Security audit
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run audit
+        run: cargo audit
+
+  megalinter:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run MegaLinter
+        uses: oxsecurity/megalinter/flavors/rust@v8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── 3. Coverage (gated on tests) ──────────────────────────────────────────
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: [test]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
@@ -56,57 +128,26 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
 
-      - name: Run tests with coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info
+      - name: Generate coverage report
+        run: |
+          cargo llvm-cov \
+            --lcov \
+            --output-path lcov.info \
+            --ignore-filename-regex 'src/(ui/|main\.rs|i18n\.rs)'
 
-      - name: Upload coverage to Codecov
+      - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
 
-  audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+  # ── 4. Cross-platform smoke builds (gated on tests) ───────────────────────
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
-
-      - name: Run cargo audit
-        run: cargo audit
-
-  megalinter:
-    name: MegaLinter
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      statuses: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Run MegaLinter
-        uses: oxsecurity/megalinter/flavors/rust@v8
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  target-matrix:
-    name: Target Matrix Smoke (${{ matrix.target }})
+  cross-platform:
+    name: Build — ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    needs: [test]
     permissions:
       contents: read
     strategy:
@@ -130,7 +171,7 @@ jobs:
             openssl_mode: system
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
@@ -150,7 +191,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools pkg-config libssl-dev
 
-      - name: Set OpenSSL paths (Windows — use Strawberry Perl's OpenSSL)
+      - name: Set OpenSSL paths (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
@@ -163,10 +204,10 @@ jobs:
           OPENSSL_NO_VENDOR: "1"
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Build (vendored fallback)
+      - name: Build (vendored OpenSSL)
         if: matrix.openssl_mode == 'vendored'
         run: cargo build --release --features openssl-vendored --target ${{ matrix.target }}
 
-      - name: Run tests on native Linux target
+      - name: Run tests (Linux native only)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: cargo test --verbose

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,9 @@
 name: Dependabot auto-merge
 
+# Automatically approves and squash-merges Dependabot PRs for
+# patch and minor dependency updates.
+# Major version bumps are left for manual review.
+
 on: pull_request
 
 permissions:
@@ -8,6 +12,7 @@ permissions:
 
 jobs:
   auto-merge:
+    name: Auto-merge patch/minor updates
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
@@ -26,7 +31,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge
+      - name: Enable auto-merge (squash)
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,9 +1,17 @@
-name: release-plz
+name: Changelog & Release PR
+
+# Runs on every push to master.
+#
+# Two outcomes depending on the state of the branch:
+#   - Pending commits exist  → open or refresh the release PR
+#     (bumps version in Cargo.toml, updates CHANGELOG.md).
+#   - Release PR was merged  → create the git tag, publish to crates.io,
+#     and create the GitHub Release.
+#     The tag push then triggers release.yml.
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
 
 permissions:
   pull-requests: write
@@ -11,18 +19,17 @@ permissions:
 
 jobs:
   release-plz:
-    name: Release-plz
+    name: Run release-plz
     runs-on: ubuntu-latest
+    # Do NOT cancel in progress: two concurrent runs can corrupt the release state.
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
-    outputs:
-      releases_created: ${{ steps.release-plz.outputs.releases_created }}
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # required: release-plz needs the full git history
+          fetch-depth: 0  # release-plz needs the full git history
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -31,11 +38,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run release-plz
-        id: release-plz
         uses: release-plz/action@v0.5
         env:
-          # A PAT is required here (not GITHUB_TOKEN) so that the tag pushed by
-          # release-plz triggers the release.yml workflow. GitHub does not fire
-          # workflow events for actions performed by the built-in GITHUB_TOKEN.
+          # Must be a PAT, not GITHUB_TOKEN: GitHub will not fire workflow events
+          # (i.e. release.yml) for tag pushes made with the built-in token.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,20 @@
 name: Release
 
+# Triggered by a version tag (vX.Y.Z) pushed by release-plz,
+# or manually via workflow_dispatch to re-publish an existing tag.
+#
+# Pipeline (parallel):
+#   build          — one binary per platform, uploaded to the GitHub Release
+#   build-deb      — amd64 + arm64 DEB packages
+#   build-rpm      — Fedora RPM package
+#
+# After build:
+#   update-pkgbuild — commits refreshed PKGBUILD to master,
+#                     which triggers aur-publish.yml
+
 on:
   push:
-    tags:
-      - "v*.*.*"
+    tags: ["v*.*.*"]
   workflow_dispatch:
     inputs:
       tag:
@@ -14,9 +25,13 @@ permissions:
   contents: write
 
 jobs:
+  # ── Platform binaries ─────────────────────────────────────────────────────
+
   build:
-    name: Build ${{ matrix.target }}
+    name: Binary — ${{ matrix.asset_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -24,63 +39,51 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_name: susshi
-            asset_name: susshi-linux-amd64
-            build_tool: cargo
+            asset_name: susshi-linux-x86_64
             openssl_mode: system
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu.2.17
-            binary_name: susshi
-            asset_name: susshi-linux-amd64-glibc217
-            build_tool: zigbuild
-            openssl_mode: vendored
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             binary_name: susshi
-            asset_name: susshi-linux-amd64-musl
-            build_tool: cargo
+            asset_name: susshi-linux-x86_64-static
             openssl_mode: vendored
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: susshi
-            asset_name: susshi-macos-amd64
-            build_tool: cargo
+            asset_name: susshi-macos-intel
             openssl_mode: vendored
           - os: macos-14
             target: aarch64-apple-darwin
             binary_name: susshi
-            asset_name: susshi-macos-arm64
-            build_tool: cargo
+            asset_name: susshi-macos-apple-silicon
             openssl_mode: system
-          # Windows support (optional, but good to have)
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: susshi.exe
-            asset_name: susshi-windows-amd64.exe
-            build_tool: cargo
+            asset_name: susshi-windows-x86_64.exe
             openssl_mode: system
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target == 'x86_64-unknown-linux-gnu.2.17' && 'x86_64-unknown-linux-gnu' || matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
 
-      - name: Install tools for Linux compatibility builds
+      - name: Install Linux build deps
         if: startsWith(matrix.target, 'x86_64-unknown-linux-')
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools pkg-config libssl-dev
 
-      - name: Install OpenSSL for Windows
+      - name: Install OpenSSL (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
@@ -90,73 +93,25 @@ jobs:
           echo "OPENSSL_DIR=$opensslDir" >> $env:GITHUB_ENV
           echo "OPENSSL_NO_VENDOR=1" >> $env:GITHUB_ENV
 
-      - name: Setup Zig
-        if: matrix.build_tool == 'zigbuild'
-        uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: 0.14.0
-
-      - name: Install cargo-zigbuild
-        if: matrix.build_tool == 'zigbuild'
-        shell: bash
-        run: cargo install cargo-zigbuild
-
-      - name: Build release (system OpenSSL)
+      - name: Build (system OpenSSL)
         if: matrix.openssl_mode == 'system'
         shell: bash
         env:
           OPENSSL_NO_VENDOR: "1"
-        run: |
-          if [ "${{ matrix.build_tool }}" = "zigbuild" ]; then
-            cargo zigbuild --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
+        run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Build release (vendored fallback)
+      - name: Build (vendored OpenSSL)
         if: matrix.openssl_mode == 'vendored'
         shell: bash
-        run: |
-          if [ "${{ matrix.build_tool }}" = "zigbuild" ]; then
-            cargo zigbuild --release --features openssl-vendored --target ${{ matrix.target }}
-          else
-            cargo build --release --features openssl-vendored --target ${{ matrix.target }}
-          fi
+        run: cargo build --release --features openssl-vendored --target ${{ matrix.target }}
 
-      - name: Check GLIBC compatibility for legacy artifact
-        if: matrix.target == 'x86_64-unknown-linux-gnu.2.17'
-        shell: bash
-        run: |
-          max_glibc=$(readelf --version-info target/x86_64-unknown-linux-gnu/release/${{ matrix.binary_name }} \
-            | grep -o 'GLIBC_[0-9.]*' \
-            | sort -V \
-            | tail -1)
-          echo "Max GLIBC required: ${max_glibc}"
-          if printf '%s\n' "GLIBC_2.17" "${max_glibc}" | sort -VC; then
-            echo "GLIBC requirement is within bounds (<= 2.17)"
-          else
-            echo "ERROR: binary requires ${max_glibc} which exceeds GLIBC_2.17"
-            exit 1
-          fi
-
-      - name: Prepare asset (Unix)
-        if: matrix.os != 'windows-latest'
-        shell: bash
-        run: |
-          TARGET_DIR="${{ matrix.target }}"
-          if [ "${{ matrix.build_tool }}" = "zigbuild" ]; then
-            TARGET_DIR="x86_64-unknown-linux-gnu"
-          fi
-          cp target/${TARGET_DIR}/release/${{ matrix.binary_name }} ${{ matrix.asset_name }}
-          chmod +x ${{ matrix.asset_name }}
-
-      - name: Prepare asset (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Copy binary to release asset name
         shell: bash
         run: |
           cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.asset_name }}
+          chmod +x ${{ matrix.asset_name }} || true
 
-      - name: Upload binaries to release
+      - name: Upload to GitHub Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,11 +120,15 @@ jobs:
           tag: ${{ github.event.inputs.tag || github.ref }}
           overwrite: true
 
+  # ── DEB packages (amd64 + arm64) ─────────────────────────────────────────
+
   build-deb:
-    name: Build DEB packages
+    name: DEB packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
@@ -187,7 +146,7 @@ jobs:
           cargo install cargo-deb
           cargo install cross
 
-      - name: Install system OpenSSL toolchain (amd64 package)
+      - name: Install system OpenSSL (amd64)
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
@@ -199,18 +158,18 @@ jobs:
           cargo build --release --target x86_64-unknown-linux-gnu
           cargo deb --no-build --target x86_64-unknown-linux-gnu
 
-      - name: Build arm64 DEB (cross)
+      - name: Build arm64 DEB (cross-compiled)
         run: |
           cross build --release --features openssl-vendored --target aarch64-unknown-linux-gnu
           cargo deb --no-build --target aarch64-unknown-linux-gnu
 
-      - name: Smoke test DEB package (amd64)
+      - name: Smoke test (amd64)
         run: |
           sudo dpkg -i target/debian/susshi_*_amd64.deb
           susshi --version
           sudo dpkg -r susshi
 
-      - name: Upload DEBs to release
+      - name: Upload to GitHub Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -219,12 +178,16 @@ jobs:
           tag: ${{ github.event.inputs.tag || github.ref }}
           overwrite: true
 
+  # ── RPM package (Fedora) ──────────────────────────────────────────────────
+
   build-rpm:
-    name: Build RPM package
+    name: RPM package
     runs-on: ubuntu-latest
     container: fedora:latest
+    permissions:
+      contents: write
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
@@ -232,10 +195,10 @@ jobs:
       - name: Install build dependencies
         run: dnf install -y rust cargo openssl-devel zlib-devel pkgconf-pkg-config rpm-build rpmdevtools git
 
-      - name: Setup rpmbuild tree
+      - name: Set up rpmbuild tree
         run: rpmdev-setuptree
 
-      - name: Patch version in spec
+      - name: Patch version in spec file
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"
@@ -245,12 +208,12 @@ jobs:
         run: spectool -g -R susshi.spec
 
       - name: Build RPM
-        run: rpmbuild -ba susshi.spec
         env:
           OPENSSL_NO_VENDOR: "1"
           LIBZ_SYS_USE_PKG_CONFIG: "1"
+        run: rpmbuild -ba susshi.spec
 
-      - name: Smoke test RPM package
+      - name: Smoke test
         shell: bash
         run: |
           shopt -s globstar
@@ -259,7 +222,7 @@ jobs:
           susshi --version
           rpm -e susshi
 
-      - name: Upload RPMs to release
+      - name: Upload to GitHub Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -267,6 +230,8 @@ jobs:
           file_glob: true
           tag: ${{ github.event.inputs.tag || github.ref }}
           overwrite: true
+
+  # ── Arch Linux PKGBUILD (committed to repo) ───────────────────────────────
 
   update-pkgbuild:
     name: Update PKGBUILD in repo
@@ -276,9 +241,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout repository
+      - name: Checkout master
         uses: actions/checkout@v6
         with:
+          # PAT required so this push triggers aur-publish.yml.
+          # GITHUB_TOKEN pushes are silently ignored by workflow event triggers.
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ref: master
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-amd6
 paru -S susshi-bin
 ```
 
-For DEB/RPM packages and legacy glibc builds see the [releases page](https://github.com/yatoub/susshi/releases/latest).
+For DEB/RPM packages see the [releases page](https://github.com/yatoub/susshi/releases/latest).
 
 > **Windows:** partial support — TUI and config parsing work, interactive SSH (PTY) and Wallix are Unix-only.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...85"
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+
+ignore:
+  # UI rendering requires a live terminal — not unit-testable
+  - "src/ui/**"
+  # Binary entry point — integration-tested via smoke tests
+  - "src/main.rs"
+  # Localization string table only
+  - "src/i18n.rs"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,10 @@
 [workspace]
+# Only open/update a release PR when at least one releasable commit is present.
+# Prevents the PKGBUILD bot-push (chore(release):) from triggering a spurious PR.
+release_commits = "^(feat|fix|perf|refactor)"
+# For 0.x crates, guarantee that feat: commits produce a minor bump (0.y → 0.y+1),
+# not a patch. Without this flag release-plz may default to patch on pre-1.0 packages.
+features_always_increment_minor = true
 # Automatically create/update the GitHub Release with the CHANGELOG section
 git_release_enable = true
 # Use the [Unreleased] section content as release notes

--- a/src/app.rs
+++ b/src/app.rs
@@ -526,3 +526,11 @@ mod tests_command;
 #[cfg(test)]
 #[path = "app/tests_selection_extended.rs"]
 mod tests_selection_extended;
+
+#[path = "app/tests_expansion_state.rs"]
+#[cfg(test)]
+mod tests_expansion_state;
+
+#[path = "app/tests_favorites.rs"]
+#[cfg(test)]
+mod tests_favorites;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -147,7 +147,7 @@ impl App {
     pub fn reload(&mut self) -> Result<(), ConfigError> {
         let mut stack = std::collections::HashSet::new();
         let (new_config, new_warnings, new_val_warnings) =
-            Config::load_merged(&self.config_path, &mut stack)?;
+            Config::load_merged(&self.config_path, &mut stack, 0)?;
         let resolved = new_config.resolve()?;
 
         self.config_hash = hash_config_file(&self.config_path);

--- a/src/app/tests_expansion_state.rs
+++ b/src/app/tests_expansion_state.rs
@@ -1,0 +1,222 @@
+use super::tests_helpers::make_namespace_env_config;
+use super::*;
+use crate::config::{ConfigEntry, Group, Server};
+
+/// Reset the state loaded from disk so tests start from a known blank state.
+fn clean(mut app: App) -> App {
+    app.expanded_items.clear();
+    app.items_dirty = true;
+    app
+}
+
+fn make_app_with_group_and_env() -> App {
+    clean(
+        App::new(
+            make_namespace_env_config(),
+            vec![],
+            std::path::PathBuf::from("/fake"),
+            vec![],
+        )
+        .unwrap(),
+    )
+}
+
+fn make_app_root_group_only() -> App {
+    let config = Config {
+        defaults: None,
+        includes: vec![],
+        groups: vec![ConfigEntry::Group(Group {
+            name: "RootOnly".to_string(),
+            user: None,
+            ssh_key: None,
+            mode: None,
+            ssh_port: None,
+            ssh_options: None,
+            wallix: None,
+            wallix_group: None,
+            jump: None,
+            probe_filesystems: None,
+            environments: None,
+            tunnels: None,
+            tags: None,
+            servers: Some(vec![Server {
+                name: "rs1".into(),
+                host: "10.1.0.1".into(),
+                ..Default::default()
+            }]),
+        })],
+        vars: Default::default(),
+    };
+    clean(App::new(config, vec![], std::path::PathBuf::from("/fake"), vec![]).unwrap())
+}
+
+fn make_app_two_servers() -> App {
+    let config = Config {
+        defaults: None,
+        includes: vec![],
+        groups: vec![ConfigEntry::Group(Group {
+            name: "Grp".to_string(),
+            user: None,
+            ssh_key: None,
+            mode: None,
+            ssh_port: None,
+            ssh_options: None,
+            wallix: None,
+            wallix_group: None,
+            jump: None,
+            probe_filesystems: None,
+            environments: None,
+            tunnels: None,
+            tags: None,
+            servers: Some(vec![
+                Server {
+                    name: "s1".into(),
+                    host: "10.0.0.1".into(),
+                    ..Default::default()
+                },
+                Server {
+                    name: "s2".into(),
+                    host: "10.0.0.2".into(),
+                    ..Default::default()
+                },
+            ]),
+        })],
+        vars: Default::default(),
+    };
+    clean(App::new(config, vec![], std::path::PathBuf::from("/fake"), vec![]).unwrap())
+}
+
+// ─── expand_all ───────────────────────────────────────────────────────────────
+
+#[test]
+fn expand_all_inserts_namespace_and_group_and_env_ids() {
+    let mut app = make_app_with_group_and_env();
+    app.expand_all();
+    assert!(
+        app.expanded_items.contains("NS:NS1"),
+        "namespace key expected"
+    );
+    assert!(
+        app.expanded_items.contains("NS:NS1:Group:GrpA"),
+        "namespaced group key expected"
+    );
+    assert!(
+        app.expanded_items.contains("NS:NS1:Env:GrpA:EnvA"),
+        "namespaced env key expected"
+    );
+}
+
+#[test]
+fn expand_all_root_group_no_ns_prefix() {
+    let mut app = make_app_root_group_only();
+    app.expand_all();
+    assert!(
+        app.expanded_items.contains("Group:RootOnly"),
+        "root group key expected, got: {:?}",
+        app.expanded_items
+    );
+    assert!(
+        !app.expanded_items.iter().any(|k| k.starts_with("NS:")),
+        "no NS: prefix expected for root-only group, got: {:?}",
+        app.expanded_items
+    );
+}
+
+#[test]
+fn expand_all_marks_items_dirty() {
+    let mut app = make_app_root_group_only();
+    app.items_dirty = false;
+    app.expand_all();
+    assert!(app.items_dirty);
+}
+
+// ─── collapse_all ─────────────────────────────────────────────────────────────
+
+#[test]
+fn collapse_all_clears_expanded_items() {
+    let mut app = make_app_with_group_and_env();
+    app.expand_all();
+    assert!(!app.expanded_items.is_empty());
+    app.collapse_all();
+    assert!(app.expanded_items.is_empty());
+}
+
+#[test]
+fn collapse_all_resets_selected_index_to_zero() {
+    let mut app = make_app_with_group_and_env();
+    app.expand_all();
+    app.selected_index = 2;
+    app.collapse_all();
+    assert_eq!(app.selected_index, 0);
+}
+
+#[test]
+fn collapse_all_marks_items_dirty() {
+    let mut app = make_app_root_group_only();
+    app.items_dirty = false;
+    app.collapse_all();
+    assert!(app.items_dirty);
+}
+
+// ─── toggle_expansion ─────────────────────────────────────────────────────────
+
+#[test]
+fn toggle_expansion_on_group_expands_it() {
+    let mut app = make_app_two_servers();
+    // Index 0 is the Group header
+    app.selected_index = 0;
+    app.toggle_expansion();
+    assert!(
+        app.expanded_items.contains("Group:Grp"),
+        "group should be expanded after toggle"
+    );
+}
+
+#[test]
+fn toggle_expansion_on_already_expanded_group_collapses_it() {
+    let mut app = make_app_two_servers();
+    app.expanded_items.insert("Group:Grp".to_string());
+    app.items_dirty = true;
+    app.selected_index = 0;
+    app.toggle_expansion();
+    assert!(
+        !app.expanded_items.contains("Group:Grp"),
+        "group should be collapsed after second toggle"
+    );
+}
+
+#[test]
+fn toggle_expansion_on_server_is_noop() {
+    let mut app = make_app_two_servers();
+    // Expand first so servers are visible
+    app.expanded_items.insert("Group:Grp".to_string());
+    app.items_dirty = true;
+    app.get_visible_items(); // force rebuild
+
+    let before = app.expanded_items.clone();
+    app.selected_index = 1; // first server
+    app.toggle_expansion();
+    // expanded_items must not change (items_dirty will be set but that's fine)
+    assert_eq!(
+        app.expanded_items, before,
+        "expanded_items must not change when toggling a server"
+    );
+}
+
+#[test]
+fn toggle_expansion_marks_items_dirty() {
+    let mut app = make_app_two_servers();
+    app.items_dirty = false;
+    app.toggle_expansion();
+    assert!(app.items_dirty);
+}
+
+// ─── invalidate_cache ─────────────────────────────────────────────────────────
+
+#[test]
+fn invalidate_cache_sets_items_dirty() {
+    let mut app = make_app_root_group_only();
+    app.items_dirty = false;
+    app.invalidate_cache();
+    assert!(app.items_dirty);
+}

--- a/src/app/tests_favorites.rs
+++ b/src/app/tests_favorites.rs
@@ -1,0 +1,174 @@
+use super::tests_helpers::make_namespace_config;
+use super::*;
+use crate::config::{ConfigEntry, Group, Server};
+
+fn make_app_with_server() -> App {
+    let config = Config {
+        defaults: None,
+        includes: vec![],
+        groups: vec![ConfigEntry::Group(Group {
+            name: "Grp".to_string(),
+            user: None,
+            ssh_key: None,
+            mode: None,
+            ssh_port: None,
+            ssh_options: None,
+            wallix: None,
+            wallix_group: None,
+            jump: None,
+            probe_filesystems: None,
+            environments: None,
+            tunnels: None,
+            tags: None,
+            servers: Some(vec![Server {
+                name: "srv1".into(),
+                host: "10.0.0.1".into(),
+                ..Default::default()
+            }]),
+        })],
+        vars: Default::default(),
+    };
+    let mut app = App::new(config, vec![], std::path::PathBuf::from("/fake"), vec![]).unwrap();
+    // Reset any persisted state and expand the group so the server is visible at index 1
+    app.expanded_items.clear();
+    app.favorites.clear();
+    app.expanded_items.insert("Group:Grp".to_string());
+    app.items_dirty = true;
+    app.get_visible_items();
+    app
+}
+
+// ─── toggle_favorite ─────────────────────────────────────────────────────────
+
+#[test]
+fn toggle_favorite_adds_server_to_favorites() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1; // the server
+    app.toggle_favorite();
+    let server = app.selected_server().unwrap();
+    let key = App::server_key(&server);
+    assert!(app.favorites.contains(&key));
+}
+
+#[test]
+fn toggle_favorite_removes_server_from_favorites_when_already_present() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1;
+    // Add to favorites first
+    app.toggle_favorite();
+    let server = app.selected_server().unwrap();
+    let key = App::server_key(&server);
+    assert!(app.favorites.contains(&key), "should be added first");
+    // Toggle again to remove
+    app.toggle_favorite();
+    assert!(
+        !app.favorites.contains(&key),
+        "should be removed after second toggle"
+    );
+}
+
+#[test]
+fn toggle_favorite_on_group_header_is_noop() {
+    let mut app = make_app_with_server();
+    app.selected_index = 0; // group header
+    let before = app.favorites.clone();
+    app.toggle_favorite();
+    assert_eq!(
+        app.favorites, before,
+        "favorites must not change when no server is selected"
+    );
+}
+
+// ─── is_selected_favorite ─────────────────────────────────────────────────────
+
+#[test]
+fn is_selected_favorite_returns_false_initially() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1;
+    assert!(!app.is_selected_favorite());
+}
+
+#[test]
+fn is_selected_favorite_returns_true_after_toggle() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1;
+    app.toggle_favorite();
+    assert!(app.is_selected_favorite());
+}
+
+#[test]
+fn is_selected_favorite_returns_false_on_group_header() {
+    let mut app = make_app_with_server();
+    app.selected_index = 0; // group header
+    assert!(!app.is_selected_favorite());
+}
+
+// ─── toggle_favorites_view ────────────────────────────────────────────────────
+
+#[test]
+fn toggle_favorites_view_sets_favorites_only() {
+    let mut app = make_app_with_server();
+    assert!(!app.favorites_only);
+    app.toggle_favorites_view();
+    assert!(app.favorites_only);
+}
+
+#[test]
+fn toggle_favorites_view_unsets_favorites_only_on_second_call() {
+    let mut app = make_app_with_server();
+    app.toggle_favorites_view();
+    app.toggle_favorites_view();
+    assert!(!app.favorites_only);
+}
+
+#[test]
+fn toggle_favorites_view_resets_selected_index_to_zero() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1;
+    app.toggle_favorites_view();
+    assert_eq!(app.selected_index, 0);
+}
+
+#[test]
+fn toggle_favorites_view_marks_items_dirty() {
+    let mut app = make_app_with_server();
+    app.items_dirty = false;
+    app.toggle_favorites_view();
+    assert!(app.items_dirty);
+}
+
+// ─── record_connection / last_seen_for ────────────────────────────────────────
+
+#[test]
+fn last_seen_for_returns_none_before_any_connection() {
+    let app = make_app_with_server();
+    let config = make_namespace_config();
+    let resolved = config.resolve().unwrap();
+    let server = resolved.first().unwrap();
+    assert!(app.last_seen_for(server).is_none());
+}
+
+#[test]
+fn record_connection_stores_nonzero_timestamp() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1;
+    let server = app.selected_server().unwrap();
+    app.record_connection(&server);
+    let ts = app.last_seen_for(&server);
+    assert!(ts.is_some(), "timestamp must be recorded");
+    assert!(ts.unwrap() > 0, "timestamp must be positive");
+}
+
+#[test]
+fn record_connection_updates_timestamp_on_second_call() {
+    let mut app = make_app_with_server();
+    app.selected_index = 1;
+    let server = app.selected_server().unwrap();
+    app.record_connection(&server);
+    let ts1 = app.last_seen_for(&server).unwrap();
+    // Sleep just enough that the second call might differ; but since SystemTime
+    // resolution is typically 1s, we just verify both calls succeed.
+    app.record_connection(&server);
+    let ts2 = app.last_seen_for(&server).unwrap();
+    assert!(ts2 >= ts1, "second timestamp must be >= first");
+}

--- a/src/app/tests_reload.rs
+++ b/src/app/tests_reload.rs
@@ -97,7 +97,7 @@ fn test_reload_detects_new_host_in_included_file() {
     .unwrap();
 
     let (config, warnings, validation_warnings) =
-        Config::load_merged(&main_path, &mut std::collections::HashSet::new()).unwrap();
+        Config::load_merged(&main_path, &mut std::collections::HashSet::new(), 0).unwrap();
     assert!(warnings.is_empty());
     assert!(validation_warnings.is_empty());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,10 @@ impl ConnectionMode {
     }
 }
 
+const MAX_INCLUDE_DEPTH: u32 = 8;
+const MAX_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024; // 5 MiB
+const HTTP_TIMEOUT_SECS: u64 = 10;
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("IO error: {0}")]
@@ -60,6 +64,10 @@ pub enum ConfigError {
     Yaml(#[from] serde_yaml_ng::Error),
     #[error("Missing configuration for server '{0}': {1}")]
     MissingField(String, String),
+    #[error("File too large: '{path}' exceeds {limit} bytes")]
+    FileTooLarge { path: String, limit: u64 },
+    #[error("Include depth limit ({limit}) exceeded at: '{path}'")]
+    IncludeDepthExceeded { path: String, limit: u32 },
 }
 
 // ─── Multi-fichiers ───────────────────────────────────────────────────────────
@@ -501,9 +509,25 @@ impl Config {
     pub fn load_merged<P: AsRef<Path>>(
         path: P,
         loading_stack: &mut HashSet<PathBuf>,
+        depth: u32,
     ) -> Result<(Self, Vec<IncludeWarning>, Vec<ValidationWarning>), ConfigError> {
         let path = path.as_ref();
         let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+        if depth > MAX_INCLUDE_DEPTH {
+            return Err(ConfigError::IncludeDepthExceeded {
+                path: canonical.display().to_string(),
+                limit: MAX_INCLUDE_DEPTH,
+            });
+        }
+
+        let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        if file_size > MAX_FILE_SIZE_BYTES {
+            return Err(ConfigError::FileTooLarge {
+                path: canonical.display().to_string(),
+                limit: MAX_FILE_SIZE_BYTES,
+            });
+        }
 
         // Lecture du contenu pour la validation ET le parsing.
         let content = std::fs::read_to_string(path)?;
@@ -613,8 +637,10 @@ impl Config {
 
             // Chargement récursif du sous-fichier
             let (mut sub_config, mut sub_inc, sub_val) =
-                match Self::load_merged(&sub_path, loading_stack) {
+                match Self::load_merged(&sub_path, loading_stack, depth + 1) {
                     Ok(r) => r,
+                    // Profondeur excessive : erreur dure, pas avertissement silencieux.
+                    Err(e @ ConfigError::IncludeDepthExceeded { .. }) => return Err(e),
                     Err(e) => {
                         inc_warnings.push(IncludeWarning::LoadError {
                             label: entry.label.clone(),
@@ -1004,9 +1030,17 @@ fn merge_default_structs(base: &Defaults, overrides: &Defaults) -> Defaults {
 
 // ─── Validation YAML ─────────────────────────────────────────────────────────
 
-/// Télécharge le contenu d'une URL HTTPS (ou HTTP) et le retourne sous forme de `String`.
+/// Télécharge le contenu d'une URL HTTPS et le retourne sous forme de `String`.
+/// Rejette les URLs HTTP non-chiffrées. Timeout global : `HTTP_TIMEOUT_SECS`.
+/// Le corps est limité à 10 Mo par défaut (limite ureq 3.x sur `read_to_string`).
 fn fetch_url(url: &str) -> Result<String, String> {
-    ureq::get(url)
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .https_only(true)
+        .timeout_global(Some(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS)))
+        .build()
+        .into();
+    agent
+        .get(url)
         .call()
         .map_err(|e| e.to_string())?
         .body_mut()
@@ -2036,7 +2070,8 @@ groups:
         let main_file = write_temp_yaml(&main_yaml);
 
         let (config, warnings, _val) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
         assert!(warnings.is_empty(), "Expected no warnings: {:?}", warnings);
 
         let resolved = config.resolve().unwrap();
@@ -2095,7 +2130,8 @@ groups:
         let main_file = write_temp_yaml(&main_yaml);
 
         let (config, warnings, _val) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
         assert!(warnings.is_empty());
 
         let resolved = config.resolve().unwrap();
@@ -2128,7 +2164,8 @@ groups:
         let main_file = write_temp_yaml(main_yaml);
 
         let (config, warnings, _val) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
 
         // Un avertissement LoadError doit être émis
         assert_eq!(warnings.len(), 1);
@@ -2182,7 +2219,8 @@ groups: []
         let main_file = write_temp_yaml(&main_yaml);
 
         let (config, warnings, _val) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
 
         // Aucun avertissement : les includes imbriqués sont désormais résolus récursivement
         assert!(
@@ -2252,7 +2290,8 @@ groups: []
         let main_file = write_temp_yaml(&main_yaml);
 
         let (config, _warnings, _val) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
         let resolved = config.resolve().unwrap();
 
         let sub_srv = resolved.iter().find(|s| s.name == "sub_srv").unwrap();
@@ -2293,7 +2332,8 @@ groups: []
         let main_file = write_temp_yaml(&main_yaml);
 
         let (config, _warnings, _val) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
         let resolved = config.resolve().unwrap();
 
         let sub_srv = resolved.iter().find(|s| s.name == "sub_srv").unwrap();
@@ -2334,7 +2374,7 @@ groups:
         std::fs::write(file_b.path(), yaml_b.as_bytes()).unwrap();
 
         let (config, warnings, _val) =
-            Config::load_merged(file_a.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(file_a.path(), &mut std::collections::HashSet::new(), 0).unwrap();
 
         let has_circular = warnings
             .iter()
@@ -2412,7 +2452,8 @@ groups: []
         let main_file = write_temp_yaml(&main_yaml);
 
         let (config, _, _) =
-            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new()).unwrap();
+            Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0)
+                .unwrap();
         let resolved = config.resolve().unwrap();
 
         let ns_srv = resolved.iter().find(|s| s.name == "ns_srv").unwrap();
@@ -3198,6 +3239,152 @@ groups:
             warnings.iter().any(|w| w.field == "bad_env_key"),
             "expected ValidationWarning for bad_env_key, got: {:?}",
             warnings
+        );
+    }
+
+    // ── ConnectionMode tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_connection_mode_next_cycles_all_three() {
+        assert_eq!(ConnectionMode::Direct.next(), ConnectionMode::Jump);
+        assert_eq!(ConnectionMode::Jump.next(), ConnectionMode::Wallix);
+        assert_eq!(ConnectionMode::Wallix.next(), ConnectionMode::Direct);
+    }
+
+    #[test]
+    fn test_connection_mode_from_index_round_trip() {
+        for i in 0..3usize {
+            let mode = ConnectionMode::from_index(i);
+            assert_eq!(mode.index(), i);
+        }
+    }
+
+    #[test]
+    fn test_connection_mode_from_index_unknown_gives_direct() {
+        assert_eq!(ConnectionMode::from_index(99), ConnectionMode::Direct);
+    }
+
+    #[test]
+    fn test_connection_mode_display() {
+        assert_eq!(ConnectionMode::Direct.to_string(), "direct");
+        assert_eq!(ConnectionMode::Jump.to_string(), "jump");
+        assert_eq!(ConnectionMode::Wallix.to_string(), "wallix");
+    }
+
+    // ── extend_tags unit tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_extend_tags_deduplication() {
+        let parent = vec!["prod".to_string(), "web".to_string()];
+        let child = vec!["web".to_string(), "db".to_string()];
+        let merged = extend_tags(Some(&parent), Some(&child));
+        assert_eq!(merged, vec!["prod", "web", "db"]);
+    }
+
+    #[test]
+    fn test_extend_tags_parent_only() {
+        let parent = vec!["a".to_string(), "b".to_string()];
+        let merged = extend_tags(Some(&parent), None);
+        assert_eq!(merged, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_extend_tags_child_only() {
+        let child = vec!["x".to_string()];
+        let merged = extend_tags(None, Some(&child));
+        assert_eq!(merged, vec!["x"]);
+    }
+
+    #[test]
+    fn test_extend_tags_both_none_empty() {
+        assert!(extend_tags(None, None).is_empty());
+    }
+
+    // ── Phase A security tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.yaml");
+        // Write a file slightly over 5 MiB
+        let content = "groups: []\n".repeat((MAX_FILE_SIZE_BYTES as usize / 10) + 1);
+        std::fs::write(&path, content).unwrap();
+        let err = Config::load_merged(&path, &mut HashSet::new(), 0).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::FileTooLarge { .. }),
+            "expected FileTooLarge, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_load_accepts_file_under_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small.yaml");
+        std::fs::write(&path, "groups: []\n").unwrap();
+        assert!(Config::load_merged(&path, &mut HashSet::new(), 0).is_ok());
+    }
+
+    #[test]
+    fn test_include_depth_exceeded() {
+        let dir = tempfile::tempdir().unwrap();
+        // Build a chain of MAX_INCLUDE_DEPTH + 2 files: A → B → … → Z
+        let depth = (MAX_INCLUDE_DEPTH + 2) as usize;
+        let paths: Vec<std::path::PathBuf> = (0..depth)
+            .map(|i| dir.path().join(format!("depth_{i}.yaml")))
+            .collect();
+        // Last file: leaf with no includes
+        std::fs::write(paths.last().unwrap(), "groups: []\n").unwrap();
+        // Each file includes the next
+        for i in (0..depth - 1).rev() {
+            let next = paths[i + 1].file_name().unwrap().to_string_lossy();
+            std::fs::write(
+                &paths[i],
+                format!("groups: []\nincludes:\n  - label: \"sub\"\n    path: \"{next}\"\n"),
+            )
+            .unwrap();
+        }
+        let err = Config::load_merged(&paths[0], &mut HashSet::new(), 0).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::IncludeDepthExceeded { .. }),
+            "expected IncludeDepthExceeded, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_include_depth_at_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // Build a chain of exactly MAX_INCLUDE_DEPTH files: depth 0 calls load_merged
+        // recursively; at depth MAX_INCLUDE_DEPTH the call still succeeds.
+        let depth = MAX_INCLUDE_DEPTH as usize;
+        let paths: Vec<std::path::PathBuf> = (0..=depth)
+            .map(|i| dir.path().join(format!("ok_{i}.yaml")))
+            .collect();
+        std::fs::write(paths.last().unwrap(), "groups: []\n").unwrap();
+        for i in (0..depth).rev() {
+            let next = paths[i + 1].file_name().unwrap().to_string_lossy();
+            std::fs::write(
+                &paths[i],
+                format!("groups: []\nincludes:\n  - label: \"sub\"\n    path: \"{next}\"\n"),
+            )
+            .unwrap();
+        }
+        assert!(
+            Config::load_merged(&paths[0], &mut HashSet::new(), 0).is_ok(),
+            "chain of {depth} levels should not exceed limit of {MAX_INCLUDE_DEPTH}"
+        );
+    }
+
+    #[test]
+    fn test_fetch_url_rejects_http_scheme() {
+        // https_only(true) rejects http:// before any network call — no mocking needed.
+        let result = fetch_url("http://example.com/config.yaml");
+        assert!(result.is_err(), "http:// URL should be rejected");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.to_lowercase().contains("http")
+                || msg.to_lowercase().contains("https")
+                || msg.to_lowercase().contains("plain"),
+            "error message should mention the scheme issue, got: {msg}"
         );
     }
 }

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,3 +1,5 @@
 pub mod ansible;
 pub mod csv;
+pub mod nmap;
 pub mod openssh;
+pub mod terraform;

--- a/src/export/nmap.rs
+++ b/src/export/nmap.rs
@@ -56,6 +56,8 @@ mod tests {
             user: "admin".to_string(),
             port,
             ssh_key: String::new(),
+            ssh_cert: String::new(),
+            ssh_agent_sock: String::new(),
             ssh_options: vec![],
             default_mode: ConnectionMode::Direct,
             jump_host: None,
@@ -81,6 +83,8 @@ mod tests {
             wallix_selection_timeout_secs: 8,
             wallix_direct: false,
             wallix_authorization: None,
+            wallix_header_columns: vec![],
+            notes: String::new(),
         }
     }
 

--- a/src/export/terraform.rs
+++ b/src/export/terraform.rs
@@ -69,6 +69,8 @@ mod tests {
             user: "admin".to_string(),
             port: 22,
             ssh_key: "~/.ssh/id_rsa".to_string(),
+            ssh_cert: String::new(),
+            ssh_agent_sock: String::new(),
             ssh_options: vec![],
             default_mode: ConnectionMode::Direct,
             jump_host: None,
@@ -94,6 +96,8 @@ mod tests {
             wallix_selection_timeout_secs: 8,
             wallix_direct: false,
             wallix_authorization: None,
+            wallix_header_columns: vec![],
+            notes: String::new(),
         }
     }
 
@@ -116,5 +120,50 @@ mod tests {
         assert_eq!(s["port"], 22);
         assert_eq!(s["group"], "prod");
         assert_eq!(s["tags"][0], "web");
+    }
+
+    #[test]
+    fn multiple_servers_all_present() {
+        let s1 = make_server("alpha", "10.0.0.1", "g1");
+        let s2 = make_server("beta", "10.0.0.2", "g2");
+        let json = to_terraform_json(&[&s1, &s2]);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["servers"].as_array().unwrap().len(), 2);
+        assert_eq!(v["servers"][0]["name"], "alpha");
+        assert_eq!(v["servers"][1]["name"], "beta");
+    }
+
+    #[test]
+    fn ssh_key_field_included() {
+        let mut srv = make_server("key-srv", "10.0.0.3", "g");
+        srv.ssh_key = "~/.ssh/prod_ed25519".into();
+        let json = to_terraform_json(&[&srv]);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["servers"][0]["ssh_key"], "~/.ssh/prod_ed25519");
+    }
+
+    #[test]
+    fn namespace_field_included() {
+        let mut srv = make_server("ns-srv", "10.0.0.4", "g");
+        srv.namespace = "MyNS".into();
+        let json = to_terraform_json(&[&srv]);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["servers"][0]["namespace"], "MyNS");
+    }
+
+    #[test]
+    fn env_field_included() {
+        let mut srv = make_server("env-srv", "10.0.0.5", "g");
+        srv.env_name = "staging".into();
+        let json = to_terraform_json(&[&srv]);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["servers"][0]["env"], "staging");
+    }
+
+    #[test]
+    fn output_ends_with_newline() {
+        let srv = make_server("nl", "10.0.0.6", "g");
+        let json = to_terraform_json(&[&srv]);
+        assert!(json.ends_with('\n'));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn validate_config(config_path: &std::path::Path) {
     }
 
     let mut stack = HashSet::new();
-    match Config::load_merged(config_path, &mut stack) {
+    match Config::load_merged(config_path, &mut stack, 0) {
         Err(e) => {
             eprintln!("ERREUR : {e}");
             process::exit(1);
@@ -534,7 +534,7 @@ fn main() -> io::Result<()> {
     }
 
     let (config, warnings, val_warnings) =
-        match Config::load_merged(config_path, &mut HashSet::new()) {
+        match Config::load_merged(config_path, &mut HashSet::new(), 0) {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("Failed to load config: {}", e);

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -1280,4 +1280,45 @@ mod tests {
         s.control_path = String::new();
         assert!(!is_control_master_active(&s));
     }
+
+    // ── askpass security tests ────────────────────────────────────────────────
+
+    /// The escaping logic for single quotes must produce the correct sh sequence '\''
+    /// so that credentials with single quotes don't break the printf argument.
+    #[test]
+    fn askpass_escape_logic_replaces_single_quotes() {
+        let cred = "it's a 'secret'";
+        let escaped = cred.replace('\'', r"'\''");
+        // Each original ' must become '\'' (end quote, escaped quote, reopen quote)
+        assert_eq!(escaped, r"it'\''s a '\''secret'\''");
+        // The original unescaped character must not appear in the middle of the string
+        // (it should only appear as part of '\'' sequences)
+        assert!(
+            !escaped.contains("it's"),
+            "original unescaped form must not survive"
+        );
+    }
+
+    /// Credentials without single quotes are not modified by the escaping logic.
+    #[test]
+    fn askpass_escape_logic_no_single_quotes_unchanged() {
+        let cred = "plainpassword123!@#";
+        let escaped = cred.replace('\'', r"'\''");
+        assert_eq!(escaped, cred);
+    }
+
+    /// The askpass script file must be created with 0o700 permissions (owner-only).
+    #[test]
+    #[cfg(unix)]
+    fn askpass_file_has_700_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let path = setup_askpass_script("hunter2_unique_permissions_test").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(
+            mode & 0o777,
+            0o700,
+            "askpass script must be owner-executable only (0o700)"
+        );
+    }
 }

--- a/tests/ssh_security.rs
+++ b/tests/ssh_security.rs
@@ -1,0 +1,207 @@
+//! Security regression tests for `ssh::client::build_ssh_args`.
+//!
+//! Verifies that dangerous characters in server fields (hostname, user,
+//! key paths, SSH options, Wallix strings) are never interpreted by a shell —
+//! they are passed as literal elements of the `Vec<String>` argument list.
+
+use susshi::config::{ConnectionMode, ResolvedServer};
+use susshi::ssh::client::build_ssh_args;
+
+fn base_server() -> ResolvedServer {
+    ResolvedServer {
+        namespace: String::new(),
+        group_name: "sec".into(),
+        env_name: "test".into(),
+        name: "srv".into(),
+        host: "10.0.0.1".into(),
+        user: "ops".into(),
+        port: 22,
+        ssh_key: String::new(),
+        ssh_options: vec![],
+        default_mode: ConnectionMode::Direct,
+        jump_host: None,
+        bastion_host: None,
+        bastion_user: None,
+        bastion_template: "{target_user}@%n:SSH:{bastion_user}".into(),
+        use_system_ssh_config: false,
+        probe_filesystems: vec![],
+        tunnels: vec![],
+        tags: vec![],
+        control_master: false,
+        agent_forwarding: false,
+        control_path: String::new(),
+        control_persist: "10m".to_string(),
+        pre_connect_hook: None,
+        post_disconnect_hook: None,
+        hook_timeout_secs: 5,
+        ssh_cert: String::new(),
+        notes: String::new(),
+        ssh_agent_sock: String::new(),
+        wallix_group: None,
+        wallix_account: "default".to_string(),
+        wallix_protocol: "SSH".to_string(),
+        wallix_auto_select: true,
+        wallix_fail_if_menu_match_error: true,
+        wallix_selection_timeout_secs: 8,
+        wallix_direct: false,
+        wallix_authorization: None,
+        wallix_header_columns: vec![],
+    }
+}
+
+// ─── Hostnames with shell metacharacters ─────────────────────────────────────
+
+/// A hostname containing shell metacharacters must be a single literal Vec element.
+#[test]
+fn hostname_with_semicolon_is_single_arg() {
+    let mut s = base_server();
+    s.host = "10.0.0.1; rm -rf /".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    let last = args.last().unwrap();
+    assert_eq!(last, "ops@10.0.0.1; rm -rf /");
+    // The semicolon must not have caused a new argument to appear
+    let semicolons_in_args = args.iter().filter(|a| a.contains("; rm")).count();
+    assert_eq!(
+        semicolons_in_args, 1,
+        "semicolon should appear in exactly one arg"
+    );
+}
+
+/// Backtick command substitution in hostname stays literal.
+#[test]
+fn hostname_with_backticks_is_literal() {
+    let mut s = base_server();
+    s.host = "10.0.0.1`whoami`".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    assert_eq!(args.last().unwrap(), "ops@10.0.0.1`whoami`");
+}
+
+/// Dollar sign / subshell syntax in hostname stays literal.
+#[test]
+fn hostname_with_dollar_subshell_is_literal() {
+    let mut s = base_server();
+    s.host = "10.0.0.1$(id)".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    assert_eq!(args.last().unwrap(), "ops@10.0.0.1$(id)");
+}
+
+// ─── Usernames with shell metacharacters ─────────────────────────────────────
+
+/// A username containing a semicolon stays as one element.
+#[test]
+fn username_with_semicolon_is_single_arg() {
+    let mut s = base_server();
+    s.user = "admin; evil".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    assert_eq!(args.last().unwrap(), "admin; evil@10.0.0.1");
+}
+
+/// A username with an embedded newline does not split into multiple args.
+#[test]
+fn username_with_newline_is_single_arg() {
+    let mut s = base_server();
+    s.user = "admin\nmalicious".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    assert_eq!(args.last().unwrap(), "admin\nmalicious@10.0.0.1");
+}
+
+// ─── SSH key paths ────────────────────────────────────────────────────────────
+
+/// Tilde in the key path is expanded before being passed to ssh.
+#[test]
+fn key_path_tilde_is_expanded() {
+    let mut s = base_server();
+    s.ssh_key = "~/.ssh/id_ed25519".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    let i_pos = args.iter().position(|a| a == "-i").expect("-i expected");
+    assert!(
+        !args[i_pos + 1].starts_with('~'),
+        "tilde must be expanded, got: {}",
+        args[i_pos + 1]
+    );
+    assert!(args[i_pos + 1].ends_with("/.ssh/id_ed25519"));
+}
+
+/// A relative key path with `../` traversal is passed through unchanged — susshi
+/// does not restrict key paths; the ssh binary is responsible for rejecting invalid paths.
+#[test]
+fn key_path_dotdot_passed_through_to_ssh() {
+    let mut s = base_server();
+    s.ssh_key = "../../etc/passwd".into();
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    let i_pos = args.iter().position(|a| a == "-i").expect("-i expected");
+    assert_eq!(args[i_pos + 1], "../../etc/passwd");
+}
+
+// ─── SSH options passthrough ──────────────────────────────────────────────────
+
+/// An SSH option containing a semicolon is passed as two args (-o and the value),
+/// not split into multiple arguments at the shell level.
+#[test]
+fn ssh_option_with_semicolon_is_two_args() {
+    let mut s = base_server();
+    s.ssh_options = vec!["ServerAliveInterval=30; rm -rf /".into()];
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    let o_pos = args.iter().position(|a| a == "-o").expect("-o expected");
+    // The value must be the single next argument
+    assert_eq!(args[o_pos + 1], "ServerAliveInterval=30; rm -rf /");
+    // No additional splitting: the '; rm' must not appear as a standalone arg
+    assert!(
+        !args.iter().any(|a| a.trim_start().starts_with("rm")),
+        "rm must not appear as a separate arg"
+    );
+}
+
+/// When the user provides `StrictHostKeyChecking`, susshi does not inject its own default.
+#[test]
+fn user_strict_host_checking_prevents_auto_inject() {
+    let mut s = base_server();
+    s.ssh_options = vec!["StrictHostKeyChecking=no".into()];
+    let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+    let accept_new_count = args
+        .iter()
+        .filter(|a| a.contains("StrictHostKeyChecking=accept-new"))
+        .count();
+    assert_eq!(
+        accept_new_count, 0,
+        "accept-new must not be injected when user already sets StrictHostKeyChecking"
+    );
+}
+
+// ─── Wallix login string ──────────────────────────────────────────────────────
+
+/// A wallix_group containing a semicolon is embedded literally in the `-l` value,
+/// not interpreted as a shell command separator.
+#[test]
+fn wallix_group_with_semicolon_is_literal_in_login_string() {
+    let mut s = base_server();
+    s.bastion_host = Some("bastion.example.com".into());
+    s.bastion_user = Some("bops".into());
+    s.wallix_group = Some("group; malicious".into());
+    let args = build_ssh_args(&s, ConnectionMode::Wallix, false).unwrap();
+    let l_pos = args.iter().position(|a| a == "-l").expect("-l expected");
+    let login = &args[l_pos + 1];
+    // The semicolon must be embedded inside the single -l value
+    assert!(login.contains("group; malicious"), "login string: {login}");
+    // Verify the total number of arguments didn't grow from the injection
+    assert!(
+        !args.iter().any(|a| a.trim_start().starts_with("malicious")),
+        "malicious must not appear as a standalone arg"
+    );
+}
+
+/// A wallix_group containing a newline stays as part of the single `-l` value.
+#[test]
+fn wallix_group_with_newline_is_single_arg() {
+    let mut s = base_server();
+    s.bastion_host = Some("bastion.example.com".into());
+    s.bastion_user = Some("bops".into());
+    s.wallix_group = Some("group\nevil-option".into());
+    let args = build_ssh_args(&s, ConnectionMode::Wallix, false).unwrap();
+    let l_pos = args.iter().position(|a| a == "-l").expect("-l expected");
+    let login = &args[l_pos + 1];
+    assert!(
+        login.contains('\n'),
+        "newline must be inside the -l value, got: {login:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Sécurité YAML** : limite de taille de fichier (5 MiB), profondeur d'include (max 8), HTTPS-only avec timeout 10 s pour les includes HTTP (`ureq` 3.x)
- **Tests de régression SSH** : nouveau fichier `tests/ssh_security.rs` — verrouille la sécurité de `build_ssh_args` contre l'injection de métacaractères shell
- **Couverture 86 %** : nouveaux tests pour `expansion_state`, `favorites`, exports `terraform`/`nmap` (modules orphelins activés), askpass escaping
- **Config couverture** : `codecov.yml` (cible 80 %, exclusion UI/main) + alias `cargo cov`
- **CI restructurée** : pipeline `lint → test → [coverage, cross-platform]`, `concurrency` cancel, noms d'assets lisibles (`susshi-macos-apple-silicon`…), bug URL AUR corrigé (`amd64` → `x86_64`)
- **release-plz** : `features_always_increment_minor = true` + `release_commits` guard → garantit un bump 0.16.0

## Test plan

- [ ] CI verte (lint + tests + audit + megalinter + cross-platform smoke)
- [ ] Codecov rapporte ≥ 80 % sur les fichiers testables
- [ ] Aucune régression sur les tests existants

🤖 Generated with [Claude Code](https://claude.com/claude-code)