### PR TITLE
chore: release v0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.16.0 -> 0.16.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.0] — 2026-05-28

### Added

- Harden YAML deserialization + improve test coverage to 86%
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).