### PR TITLE
fix(ci): use prs_created to gate release PR auto-merge

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,7 +48,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Auto-merge release PR
-        if: steps.release-plz.outputs.pr != ''
+        if: steps.release-plz.outputs.prs_created == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           PR_URL: ${{ fromJson(steps.release-plz.outputs.pr).html_url }}


### PR DESCRIPTION
## Problème

Quand release-plz ne crée pas de PR (commits non-releasables), le output `pr` vaut `"null"` (littéral), pas une chaîne vide. La condition `pr != ''` passait quand même → `gh pr merge` s'exécutait avec `PR_URL` vide → erreur "no pull requests found for branch master".

## Fix

Remplace `steps.release-plz.outputs.pr != ''` par `steps.release-plz.outputs.prs_created == 'true'`.  
`prs_created` est explicitement `'true'`/`'false'` — pas d'ambiguïté.

## Test plan

- [ ] Merger et vérifier que le prochain push sans commit releasable ne déclenche pas d'erreur dans release-plz.yml
- [ ] Vérifier que la prochaine release PR s'auto-merge bien

🤖 Generated with [Claude Code](https://claude.com/claude-code)