### PR TITLE
feat(docs): add GitHub Pages site and improve project visibility

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [yatoub]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material pillow cairosvg
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add PKGBUILD PKGBUILD.bin .SRCINFO
+          git add PKGBUILD PKGBUILD.bin .SRCINFO susshi.spec
           if git diff --cached --quiet; then
             echo "No changes to commit"
             exit 0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "susshi"
 version = "0.17.0"
 edition = "2024"
 rust-version = "1.88"
-description = "A modern terminal-based SSH connection manager with a beautiful Catppuccin TUI"
+description = "Terminal SSH manager with YAML inventories, multi-hop jump hosts, Wallix bastion, tunnels, SCP, and Catppuccin TUI"
 license = "MIT"
 repository = "https://github.com/yatoub/susshi"
-homepage = "https://github.com/yatoub/susshi"
-documentation = "https://github.com/yatoub/susshi/blob/master/README.md"
-keywords = ["ssh", "tui", "terminal", "manager", "ratatui"]
-categories = ["command-line-utilities", "network-programming"]
+homepage = "https://yatoub.github.io/susshi/"
+documentation = "https://yatoub.github.io/susshi/"
+keywords = ["ssh", "tui", "terminal", "manager", "bastion"]
+categories = ["command-line-utilities", "network-programming", "development-tools"]
 exclude = ["target/", ".idea/", ".github/"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/yatoub/susshi/ci.yml?branch=master&style=flat-square)](https://github.com/yatoub/susshi/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/susshi?style=flat-square)](https://crates.io/crates/susshi)
 [![Crates downloads](https://img.shields.io/crates/d/susshi?style=flat-square)](https://crates.io/crates/susshi)
+[![Documentation](https://img.shields.io/badge/docs-yatoub.github.io%2Fsusshi-blue?style=flat-square)](https://yatoub.github.io/susshi/)
 
 [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue?style=flat-square)](Cargo.toml)
 [![Maintenance](https://img.shields.io/badge/maintenance-active-brightgreen?style=flat-square)](https://github.com/yatoub/susshi)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+Planned features and long-term direction. Items are subject to change based on community feedback — open an [issue](https://github.com/yatoub/susshi/issues) to discuss priorities.
+
+Full roadmap with version history: [yatoub.github.io/susshi/roadmap/](https://yatoub.github.io/susshi/roadmap/)
+
+## Recently shipped
+
+| Version | Highlights |
+| --- | --- |
+| v0.17 | Improved README and documentation badges |
+| v0.16 | Hardened YAML deserialization, 86 % test coverage |
+| v0.15 | Fuzzy search, manpage, Wallix custom headers, OpenSSH/CSV/Terraform/Nmap export, SSH agent socket per server, SCP, command history, notes field, live theme toggle |
+
+## Near-term
+
+- [ ] **Homebrew tap** — `brew install yatoub/tap/susshi` for macOS users without cargo
+- [ ] **First-run wizard** — interactive prompt to create `~/.susshi.yml` on first launch
+- [ ] **Connection log** — persist last-connected timestamp and last-run command per server
+- [ ] **Multi-select operations** — apply tunnels, SCP, or exec-group to several servers at once
+
+## Long-term
+
+- [ ] **Config UI** — edit the inventory from within the TUI without touching YAML
+- [ ] **Full Windows TUI** — PTY support on Windows (currently config-only)
+- [ ] **Plugin system** — hook into the connection lifecycle with external binaries
+- [ ] **susshi sync** — optional encrypted config sync via a self-hosted backend (privacy-preserving, no cloud dependency)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,120 @@
+---
+description: Install susshi and connect to your first server in under 5 minutes.
+---
+
+# Getting Started
+
+Get up and running with susshi in under 5 minutes.
+
+## Prerequisites
+
+- Linux, macOS, or WSL
+- `ssh` client installed (`openssh-client` / `openssh`)
+
+## Install
+
+=== "Arch Linux"
+    ```bash
+    paru -S susshi-bin
+    ```
+
+=== "Linux (binary)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-linux-x86_64
+    chmod +x susshi-linux-x86_64 && sudo mv susshi-linux-x86_64 /usr/local/bin/susshi
+    ```
+
+=== "Linux (musl / static)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-linux-x86_64-static
+    chmod +x susshi-linux-x86_64-static && sudo mv susshi-linux-x86_64-static /usr/local/bin/susshi
+    ```
+
+=== "macOS (Apple Silicon)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-apple-silicon
+    chmod +x susshi-macos-apple-silicon && sudo mv susshi-macos-apple-silicon /usr/local/bin/susshi
+    ```
+
+=== "macOS (Intel)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-intel
+    chmod +x susshi-macos-intel && sudo mv susshi-macos-intel /usr/local/bin/susshi
+    ```
+
+=== "Cargo"
+    ```bash
+    cargo install susshi
+    ```
+
+=== "DEB / RPM"
+    Download from the [releases page](https://github.com/yatoub/susshi/releases/latest).
+
+Verify:
+
+```bash
+susshi --version
+```
+
+## Create your first inventory
+
+Create `~/.susshi.yml`:
+
+```yaml
+defaults:
+  user: "your-user"
+  ssh_key: "~/.ssh/id_ed25519"
+
+groups:
+  - name: "My Servers"
+    servers:
+      - name: "web-01"
+        host: "192.168.1.10"
+        mode: "direct"
+      - name: "db-01"
+        host: "192.168.1.20"
+        mode: "direct"
+```
+
+## Launch the TUI
+
+```bash
+susshi
+```
+
+You'll see your server list. Navigate with `j`/`k`, press `Enter` to connect, `/` to search.
+
+## Essential keybindings
+
+| Key | Action |
+| --- | --- |
+| `j` / `k` or `↓` / `↑` | Move down / up |
+| `Enter` | Connect or toggle group |
+| `/` | Fuzzy search |
+| `Tab` | Switch mode (Direct / Jump / Wallix) |
+| `f` | Toggle favorite |
+| `F` | Show favorites only |
+| `T` | Tunnel manager |
+| `E` | Expand all groups |
+| `h` | Keyboard help overlay |
+| `q` | Quit |
+
+## One-shot connection (no TUI)
+
+```bash
+susshi --direct your-user@192.168.1.10
+```
+
+## Validate your config
+
+```bash
+susshi --validate
+```
+
+Checks YAML syntax, variable resolution, and SSH key existence without opening a connection.
+
+## Next steps
+
+- [Configuration reference](configuration.md) — full schema, inheritance, variables, includes
+- [TUI Guide](tui.md) — all keybindings, search syntax, tag filters, diagnostics
+- [Use Cases](use-cases.md) — jump hosts, Wallix bastions, multi-environment setups

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,91 @@
+---
+description: susshi is a terminal SSH manager with YAML inventories, multi-hop jump hosts, Wallix bastion, tunnels, SCP, and Catppuccin TUI — written in Rust.
+---
+
+# susshi 🍣
+
+**susshi** is a terminal-based SSH connection manager written in Rust — hierarchical YAML inventory, Catppuccin-themed TUI, jump hosts, Wallix bastions, tunnels, and SCP in one place.
+
+[Get Started](getting-started.md){ .md-button .md-button--primary }
+[View on GitHub](https://github.com/yatoub/susshi){ .md-button }
+
+---
+
+<script async id="asciicast-1154653" src="https://asciinema.org/a/1154653.js"></script>
+
+---
+
+## Why susshi?
+
+Managing dozens or hundreds of hosts with a single `~/.ssh/config` quickly becomes fragile: no centralized visibility, no interactive interface, limited grouping, and poor ergonomics for day-to-day tasks.
+
+`susshi` addresses these gaps:
+
+- **Ergonomics & speed** — fuzzy search, keyboard-driven navigation, one-key connect. No editing files and re-running commands.
+- **Infrastructure visibility** — hierarchical groups, favorites, tag filters, interactive inventory at a glance.
+- **Bastion & multi-hop workflows** — automatic orchestration of jump hops and Wallix integration without repetitive `ssh_config` entries.
+- **Inventory management** — variable inheritance, environment profiles, YAML includes, and exports to Ansible/Terraform/Nmap/CSV.
+- **Built-in operations** — tunnels, SCP, pre/post-connect hooks, `--validate` checks.
+- **Security & privacy** — local-first, no cloud dependency, no telemetry.
+
+## How it compares
+
+| Feature | **susshi** 🍣 | **SSH Config** 📄 | **Termius / Warp** ☁️ | **ClusterSSH** 🕸️ |
+| :--- | :--- | :--- | :--- | :--- |
+| Interface | Modern interactive TUI | Raw text / `grep` | Heavy GUI / Electron | Outdated X11 windows |
+| Speed | Instant (native Rust) | Instant | Resource-heavy | Laggy on modern systems |
+| Privacy | 100% local & open source | 100% local | Cloud-first / proprietary | Local |
+| Workflow | Fuzzy search & tags | Manual typing | Mouse-driven | Multi-window |
+| Terminal | Any terminal emulator | Any terminal | Forces their own app | Requires X11 |
+
+## Quick install
+
+=== "Arch Linux"
+    ```bash
+    paru -S susshi-bin
+    ```
+
+=== "Linux (binary)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-linux-x86_64
+    chmod +x susshi-linux-x86_64 && sudo mv susshi-linux-x86_64 /usr/local/bin/susshi
+    ```
+
+=== "macOS (Apple Silicon)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-apple-silicon
+    chmod +x susshi-macos-apple-silicon && sudo mv susshi-macos-apple-silicon /usr/local/bin/susshi
+    ```
+
+=== "macOS (Intel)"
+    ```bash
+    wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-intel
+    chmod +x susshi-macos-intel && sudo mv susshi-macos-intel /usr/local/bin/susshi
+    ```
+
+=== "Cargo"
+    ```bash
+    cargo install susshi
+    ```
+
+For DEB/RPM packages see the [releases page](https://github.com/yatoub/susshi/releases/latest).
+
+## What's included
+
+| Feature | Description |
+| --- | --- |
+| Fuzzy search | Filter hundreds of servers instantly with `#tag` and text queries |
+| Jump hosts | Multi-hop connections without manual `ProxyJump` chains |
+| Wallix bastion | Full Wallix auth menu integration |
+| SSH tunnels | Persistent tunnels with in-TUI manager |
+| SCP transfers | File transfers without leaving the terminal |
+| Import / Export | Import from `~/.ssh/config`, export to Ansible, Terraform, Nmap, CSV |
+| Hooks | Shell scripts triggered before connect / after disconnect |
+| Themes | Live Catppuccin theme toggle (latte / frappe / macchiato / mocha) |
+
+## Next steps
+
+- [Getting Started](getting-started.md) — install, first config, first connection
+- [Configuration](configuration.md) — full YAML schema and inheritance model
+- [Use Cases](use-cases.md) — real-world setups for jump hosts, Wallix, multi-env
+- [Roadmap](roadmap.md) — what's coming next

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "susshi",
+    "description": "Terminal SSH manager with YAML inventories, multi-hop jump hosts, Wallix bastion, tunnels, SCP, and Catppuccin TUI — written in Rust.",
+    "url": "https://yatoub.github.io/susshi/",
+    "downloadUrl": "https://github.com/yatoub/susshi/releases/latest",
+    "softwareVersion": "{{ config.extra.version | default('latest') }}",
+    "operatingSystem": "Linux, macOS, Windows",
+    "applicationCategory": "DeveloperApplication",
+    "applicationSubCategory": "NetworkingApplication",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "license": "https://opensource.org/licenses/MIT",
+    "codeRepository": "https://github.com/yatoub/susshi",
+    "programmingLanguage": "Rust",
+    "author": {
+      "@type": "Person",
+      "name": "yatoub",
+      "url": "https://github.com/yatoub"
+    }
+  }
+  </script>
+{% endblock %}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,33 @@
+---
+description: Planned features and long-term direction for susshi.
+---
+
+# Roadmap
+
+Planned features and long-term direction. Items are subject to change based on community feedback — open an [issue](https://github.com/yatoub/susshi/issues) to discuss priorities.
+
+## Recently shipped
+
+| Version | Highlights |
+| --- | --- |
+| v0.17 | Improved README and documentation badges |
+| v0.16 | Hardened YAML deserialization, 86 % test coverage |
+| v0.15 | Fuzzy search, manpage, Wallix custom headers, OpenSSH/CSV/Terraform/Nmap export, SSH agent socket per server, SCP, command history, notes field, live theme toggle |
+
+## Near-term
+
+- [ ] **Homebrew tap** — `brew install yatoub/tap/susshi` for macOS users without cargo
+- [ ] **First-run wizard** — interactive prompt to create `~/.susshi.yml` on first launch
+- [ ] **Connection log** — persist last-connected timestamp and last-run command per server
+- [ ] **Multi-select operations** — apply tunnels, SCP, or exec-group to several servers at once
+
+## Long-term
+
+- [ ] **Config UI** — edit the inventory from within the TUI without touching YAML
+- [ ] **Full Windows TUI** — PTY support on Windows (currently config-only)
+- [ ] **Plugin system** — hook into the connection lifecycle with external binaries
+- [ ] **susshi sync** — optional encrypted config sync via a self-hosted backend (privacy-preserving, no cloud dependency)
+
+## How to contribute
+
+Ideas, bug reports, and PRs are welcome. See [CONTRIBUTING.md](https://github.com/yatoub/susshi/blob/master/CONTRIBUTING.md) for conventions and the commit message format required by the automated release pipeline.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://yatoub.github.io/susshi/sitemap.xml

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,19 @@
+/* Catppuccin Mocha palette for dark mode */
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #f5c2e7;
+  --md-primary-fg-color--light: #f5c2e7;
+  --md-primary-fg-color--dark:  #cba6f7;
+  --md-accent-fg-color:         #cba6f7;
+  --md-default-bg-color:        #1e1e2e;
+  --md-default-bg-color--light: #181825;
+  --md-code-bg-color:           #181825;
+  --md-code-fg-color:           #cdd6f4;
+}
+
+/* Catppuccin Latte palette for light mode */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        #ea76cb;
+  --md-primary-fg-color--light: #ea76cb;
+  --md-primary-fg-color--dark:  #8839ef;
+  --md-accent-fg-color:         #8839ef;
+}

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,199 @@
+---
+description: Real-world susshi configurations for jump hosts, Wallix bastions, multi-environment teams, tunnels, and SCP.
+---
+
+# Use Cases
+
+Concrete susshi configurations for common infrastructure setups.
+
+## Team managing a large server fleet
+
+When your `~/.ssh/config` grows beyond a few dozen hosts, susshi's hierarchical inventory keeps things navigable.
+
+```yaml
+defaults:
+  user: "ops"
+  ssh_key: "~/.ssh/id_ed25519"
+
+groups:
+  - name: "Production"
+    tags: ["prod"]
+    servers:
+      - name: "api-01"
+        host: "10.0.1.10"
+        tags: ["api", "critical"]
+      - name: "api-02"
+        host: "10.0.1.11"
+        tags: ["api", "critical"]
+      - name: "db-primary"
+        host: "10.0.2.10"
+        tags: ["db", "critical"]
+
+  - name: "Staging"
+    tags: ["staging"]
+    servers:
+      - name: "api-staging"
+        host: "10.1.1.10"
+        tags: ["api"]
+```
+
+Use `#prod` or `#api #critical` in the `/` search bar to filter instantly. Star frequently-used servers with `f` and toggle the favorites-only view with `F`.
+
+---
+
+## Multi-hop jump hosts
+
+Connect through one or more bastion hosts without writing manual `ProxyJump` chains.
+
+```yaml
+defaults:
+  user: "ops"
+  ssh_key: "~/.ssh/id_ed25519"
+
+groups:
+  - name: "Internal (via bastion)"
+    jump:
+      - host: "bastion.example.com"
+        user: "jump-user"
+        ssh_key: "~/.ssh/jump_key"
+    servers:
+      - name: "internal-db"
+        host: "172.16.0.10"
+        mode: "jump"
+      - name: "internal-api"
+        host: "172.16.0.20"
+        mode: "jump"
+```
+
+susshi builds the full `ProxyJump` chain automatically. Override `mode` on any individual server to bypass the jump for that host.
+
+### Three-hop chain
+
+```yaml
+jump:
+  - host: "public-bastion.example.com"
+    user: "jump1"
+  - host: "internal-bastion.corp"
+    user: "jump2"
+```
+
+---
+
+## Wallix bastion
+
+For teams using a Wallix bastion, susshi handles the auth menu interactively.
+
+```yaml
+defaults:
+  user: "ops@domain"
+
+groups:
+  - name: "Wallix Production"
+    wallix:
+      host: "wallix.corp.internal"
+      port: 22
+      user: "ops@domain"
+      ssh_key: "~/.ssh/wallix_key"
+    servers:
+      - name: "prod-web-01"
+        host: "prod-web-01"
+        mode: "wallix"
+      - name: "prod-db-01"
+        host: "prod-db-01"
+        mode: "wallix"
+```
+
+susshi connects to the bastion, presents its interactive target menu, and you select the final destination. See [Wallix bastion](wallix.md) for advanced configuration including `header_columns` customization.
+
+---
+
+## Multi-environment with variable inheritance
+
+Avoid duplicating connection settings across staging, pre-prod, and production.
+
+```yaml
+defaults:
+  user: "deploy"
+  ssh_key: "~/.ssh/deploy_key"
+
+groups:
+  - name: "App Cluster"
+    environments:
+      - name: "staging"
+        ssh_key: "~/.ssh/staging_key"
+        servers:
+          - name: "app-staging-01"
+            host: "staging-01.internal"
+      - name: "production"
+        servers:
+          - name: "app-prod-01"
+            host: "prod-01.internal"
+          - name: "app-prod-02"
+            host: "prod-02.internal"
+```
+
+The `staging` environment overrides only `ssh_key`; all other settings inherit from `defaults`. Switch modes with `Tab` if a server supports both direct and jump access.
+
+---
+
+## SSH tunnels for development
+
+Forward a remote service port to localhost without keeping a terminal open.
+
+```yaml
+defaults:
+  user: "dev"
+
+groups:
+  - name: "Dev tunnels"
+    servers:
+      - name: "remote-postgres"
+        host: "dev-db.example.com"
+        mode: "direct"
+        tunnels:
+          - local_port: 5433
+            remote_host: "localhost"
+            remote_port: 5432
+```
+
+Open the tunnel manager with `T`, start/stop tunnels without disconnecting. Tunnel state persists between susshi sessions.
+
+---
+
+## SCP file transfers
+
+Transfer files to/from any server in your inventory with `s` (SCP mode).
+
+Useful for:
+
+- Uploading config files to multiple servers
+- Retrieving logs without `rsync` setup
+- Copying build artifacts to a staging server
+
+See [SCP Transfers](scp.md) for full usage.
+
+---
+
+## Ansible export
+
+Once your inventory is in susshi, export it to Ansible format:
+
+```bash
+susshi --export ansible > inventory.yml
+```
+
+Other export formats: `--export terraform`, `--export nmap`, `--export csv`, `--export openssh`.
+
+See [Import & Export](import-export.md) for details.
+
+---
+
+## Import from `~/.ssh/config`
+
+Migrate your existing SSH config into susshi in one step:
+
+```bash
+susshi --import-ssh-config
+```
+
+susshi reads `~/.ssh/config`, groups hosts by their `Match` / `Host` blocks, and writes a `~/.susshi.yml` skeleton that you can refine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,85 @@
+site_name: Susshi
+site_description: >
+  Terminal SSH manager with YAML inventories, multi-hop jump hosts,
+  Wallix bastion, tunnels, SCP, and Catppuccin TUI — written in Rust.
+site_url: https://yatoub.github.io/susshi/
+repo_url: https://github.com/yatoub/susshi
+repo_name: yatoub/susshi
+edit_uri: edit/master/docs/
+
+theme:
+  name: material
+  logo: susshi.png
+  favicon: susshi.png
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: pink
+      accent: pink
+      toggle:
+        icon: material/weather-night
+        name: Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: pink
+      accent: pink
+      toggle:
+        icon: material/weather-sunny
+        name: Light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - TUI Guide: tui.md
+  - CLI Reference: cli.md
+  - Features:
+    - Tunnels: tunnels.md
+    - SCP Transfers: scp.md
+    - Wallix Bastion: wallix.md
+    - Import & Export: import-export.md
+    - SSH Advanced: ssh-advanced.md
+    - Hooks: hooks.md
+  - Use Cases: use-cases.md
+  - Troubleshooting: troubleshooting.md
+  - Roadmap: roadmap.md
+
+plugins:
+  - search
+  - social:
+      cards_layout_options:
+        background_color: "#1e1e2e"
+        color: "#cdd6f4"
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yatoub/susshi
+      name: susshi on GitHub
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.inlinehilite
+  - admonition
+  - pymdownx.details
+  - tables
+  - attr_list
+  - def_list
+  - toc:
+      permalink: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ edit_uri: edit/master/docs/
 
 theme:
   name: material
+  custom_dir: docs/overrides
   logo: susshi.png
   favicon: susshi.png
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,12 +43,12 @@ nav:
   - TUI Guide: tui.md
   - CLI Reference: cli.md
   - Features:
-    - Tunnels: tunnels.md
-    - SCP Transfers: scp.md
-    - Wallix Bastion: wallix.md
-    - Import & Export: import-export.md
-    - SSH Advanced: ssh-advanced.md
-    - Hooks: hooks.md
+      - Tunnels: tunnels.md
+      - SCP Transfers: scp.md
+      - Wallix Bastion: wallix.md
+      - Import & Export: import-export.md
+      - SSH Advanced: ssh-advanced.md
+      - Hooks: hooks.md
   - Use Cases: use-cases.md
   - Troubleshooting: troubleshooting.md
   - Roadmap: roadmap.md

--- a/scripts/update-pkgbuild.sh
+++ b/scripts/update-pkgbuild.sh
@@ -25,4 +25,7 @@ sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD.bin
 sed -i "s/^b2sums=(.*/b2sums=('${B2SUM}')/" PKGBUILD.bin
 sed -i "s/^b2sums_x86_64=(.*/b2sums_x86_64=('${B2SUM_BIN}')/" PKGBUILD.bin
 
+echo "Updating susshi.spec to ${VERSION}..."
+sed -i "s/^Version:.*/Version:        ${VERSION}/" susshi.spec
+
 echo "Done: pkgver=${VERSION}, b2sums=${B2SUM}, b2sums_x86_64=${B2SUM_BIN}"

--- a/susshi.spec
+++ b/susshi.spec
@@ -1,7 +1,7 @@
 Name:           susshi
-Version:        0.14.0
+Version:        0.17.0
 Release:        1%{?dist}
-Summary:        Modern terminal-based SSH connection manager
+Summary:        Terminal SSH manager — TUI, YAML inventory, jump hosts, Wallix bastion, tunnels, SCP
 License:        MIT
 URL:            https://github.com/yatoub/susshi
 Source0:        https://github.com/yatoub/susshi/archive/refs/tags/v%{version}.tar.gz
@@ -12,8 +12,10 @@ BuildRequires:  zlib-devel
 Requires:       openssh-clients
 
 %description
-susshi is a modern TUI SSH connection manager with Catppuccin theme,
-supporting direct, jump, and Wallix bastion connections.
+susshi is a terminal-based SSH connection manager written in Rust.
+It provides a Catppuccin-themed TUI with hierarchical YAML inventories,
+multi-hop jump hosts, Wallix bastion integration, SSH tunnels, SCP
+transfers, Ansible/Terraform export, fuzzy search, and per-server hooks.
 
 %prep
 %autosetup -n %{name}-%{version}


### PR DESCRIPTION
## Summary

- **GitHub Pages** (`mkdocs.yml` + `docs.yml` workflow): site statique MkDocs Material déployé automatiquement sur push master → `https://yatoub.github.io/susshi/`
- **Landing page** (`docs/index.md`): page SEO avec embed asciinema, tableau de comparaison, install tabs, meta description
- **Getting Started** (`docs/getting-started.md`): parcours zéro-à-première-connexion en < 5 min
- **Use Cases** (`docs/use-cases.md`): jump hosts, Wallix, multi-env, tunnels, SCP, export Ansible
- **Roadmap** (`docs/roadmap.md` + `ROADMAP.md`): direction near/long-term, ancre pour contributeurs
- **Cargo.toml**: `homepage` mis à jour vers le site Pages
- **susshi.spec**: synchronisé à v0.17.0, description enrichie
- **scripts/update-pkgbuild.sh**: sync automatique du spec à chaque release
- **release.yml**: `susshi.spec` inclus dans le commit post-release
- **FUNDING.yml**: bouton Sponsor GitHub activé
- **Thème**: palette Catppuccin Mocha/Latte via CSS custom properties

## Après merge

1. Dans les settings GitHub du repo → **Pages → Source = Deploy from a branch → `gh-pages` / root**
2. Le workflow `docs.yml` se déclenche au prochain push master et publie le site
3. Vérifier `https://yatoub.github.io/susshi/sitemap.xml` pour l'indexation Google
4. Ajouter `CODE_OF_CONDUCT.md` via le bouton GitHub "Add file → Code of conduct" (Contributor Covenant 2.1)
5. Pour le Homebrew tap (niveau 3) : créer un repo `homebrew-tap` séparé

## Test plan

- [ ] `pip install mkdocs-material pillow cairosvg && mkdocs build` — site généré sans erreur
- [ ] Navigation : tous les liens dans `mkdocs.yml` correspondent à des fichiers existants
- [ ] Open Graph cards générées dans `site/assets/images/`
- [ ] `sitemap.xml` présent dans `site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)