### PR TITLE
fix(ci): select main RPM package in smoke test, not debugsource

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Smoke test
         shell: bash
         run: |
-          rpm_file=$(find /github/home/rpmbuild/RPMS -name "*.rpm" | head -n1)
+          rpm_file=$(find /github/home/rpmbuild/RPMS -name "susshi-*.rpm" | grep -v debug | head -n1)
           dnf install -y "${rpm_file}"
           susshi --version
           rpm -e susshi


### PR DESCRIPTION
## Summary

- `find … "*.rpm" | head -n1` was returning `susshi-debugsource-*.rpm` first (alphabetical order before the main package)
- The debugsource package doesn't install the `susshi` binary, so `susshi --version` exited with code 127
- This caused the Release workflow to fail, which in turn caused `aur-publish.yml` to skip (its jobs gate on `conclusion == 'success'`)

**Fix:** filter `find` to `susshi-*.rpm | grep -v debug` so only the main package is selected for installation.

## Test plan

- [ ] Trigger a re-run of the Release workflow (via `workflow_dispatch`) against an existing tag (e.g. `v0.18.0`) and confirm the RPM smoke test passes
- [ ] Confirm `aur-publish` runs after the Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)