### PR TITLE
fix(ci): resolve AUR tag from HEAD_SHA, not workflow_run.head_branch

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -30,16 +30,26 @@ jobs:
       contents: read
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
 
     steps:
       - name: Resolve version to publish
         id: ver
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
-          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="${INPUT_TAG:-$RUN_HEAD_BRANCH}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            # workflow_run.head_branch is always the branch name (e.g. "master"),
+            # not the tag. Resolve by finding the tag that points to HEAD_SHA.
+            TAG=$(git ls-remote --tags "https://github.com/${REPO}.git" 'refs/tags/v*' \
+              | awk -v sha="$HEAD_SHA" \
+                  '$1 == sha { gsub(/refs\/tags\//, "", $2); gsub(/\^\{\}$/, "", $2); if ($2 ~ /^v[0-9]/) { print $2; exit } }')
+          fi
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
             echo "Invalid tag format: $TAG" >&2
             exit 1
@@ -88,16 +98,24 @@ jobs:
       contents: read
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
 
     steps:
       - name: Resolve version to publish
         id: ver
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
-          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="${INPUT_TAG:-$RUN_HEAD_BRANCH}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG=$(git ls-remote --tags "https://github.com/${REPO}.git" 'refs/tags/v*' \
+              | awk -v sha="$HEAD_SHA" \
+                  '$1 == sha { gsub(/refs\/tags\//, "", $2); gsub(/\^\{\}$/, "", $2); if ($2 ~ /^v[0-9]/) { print $2; exit } }')
+          fi
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
             echo "Invalid tag format: $TAG" >&2
             exit 1


### PR DESCRIPTION
## Summary

- `workflow_run.head_branch` is always the branch name (`master`), not the tag name — even when the Release workflow was triggered by a tag push. This caused `TAG=master` → `Invalid tag format: master` → both `aur-source` and `aur-bin` jobs fail.
- Additionally, a manual `workflow_dispatch` of the Release workflow on `master` (e.g. to re-test a fix) would also trigger `aur-publish` with no valid tag, producing the same error.

## Changes

**`aur-source` and `aur-bin` job conditions** — added `github.event.workflow_run.event == 'push'` guard:
```
(github.event.workflow_run.conclusion == 'success' &&
 github.event.workflow_run.event == 'push')
```
This prevents aur-publish from being triggered by manual `workflow_dispatch` Release runs on a branch (which don't correspond to a real release tag).

**Version resolution** — replaced `RUN_HEAD_BRANCH` with a `git ls-remote` lookup on `HEAD_SHA`:
```bash
TAG=$(git ls-remote --tags "https://github.com/${REPO}.git" 'refs/tags/v*' \
  | awk -v sha="$HEAD_SHA" \
      '$1 == sha { gsub(/refs\/tags\//, "", $2); gsub(/\^\{\}$/, "", $2); if ($2 ~ /^v[0-9]/) { print $2; exit } }')
```
Works for both lightweight tags (SHA matches directly) and annotated tags (SHA matches the `^{}` peeled entry).

## Test plan

- [ ] Merge and let the next tag-triggered release run — confirm `aur-source` and `aur-bin` succeed
- [ ] Manually dispatch the Release workflow on `master` — confirm `aur-publish` is now **skipped** (not failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)