### PR TITLE
ci: auto-delete branches after merge + cleanup stale release-plz branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             openssl_mode: system
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            openssl_mode: system
 
     steps:
       - name: Checkout
@@ -242,11 +245,16 @@ jobs:
           shared-key: ${{ matrix.target }}
 
       - name: Install Linux build deps
-        if: startsWith(matrix.os, 'ubuntu')
+        if: contains(matrix.target, 'unknown-linux')
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools pkg-config libssl-dev
+          sudo apt-get install -y pkg-config libssl-dev
+          if [[ "$TARGET" == *musl* ]]; then
+            sudo apt-get install -y musl-tools
+          fi
 
       - name: Set OpenSSL paths (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          shared-key: ${{ matrix.target }}
 
       - name: Install Linux build deps
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,12 @@ jobs:
       - name: Install Linux build deps
         if: contains(matrix.target, 'unknown-linux')
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
-          if [[ "${{ matrix.target }}" == *musl* ]]; then
+          if [[ "$TARGET" == *musl* ]]; then
             sudo apt-get install -y musl-tools
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,3 +303,27 @@ jobs:
           VERSION="${TAG#v}"
           git commit -m "chore(release): update PKGBUILD to v${VERSION}"
           git push
+
+  # ── Cleanup stale release-plz branches ───────────────────────────────────
+
+  cleanup-branches:
+    name: Cleanup stale release-plz branches
+    runs-on: ubuntu-latest
+    needs: [update-pkgbuild]
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - name: Delete closed release-plz branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/branches" --paginate \
+            --jq '.[].name | select(startswith("release-plz-"))' \
+          | while IFS= read -r branch; do
+              open=$(gh pr list --head "$branch" --state open --json number --jq 'length')
+              if [ "$open" = "0" ]; then
+                gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$branch" \
+                  && echo "Deleted: $branch" || true
+              fi
+            done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
   # ── RPM package (Fedora) ──────────────────────────────────────────────────
 
   build-rpm:
-    name: RPM package
+    name: RPM package (x86_64)
     runs-on: ubuntu-latest
     container: fedora:latest
     permissions:
@@ -194,6 +194,18 @@ jobs:
 
       - name: Install build dependencies
         run: dnf install -y rust cargo openssl-devel zlib-devel pkgconf-pkg-config rpm-build rpmdevtools git
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            /github/home/.cargo/registry/index
+            /github/home/.cargo/registry/cache
+            /github/home/.cargo/git/db
+            /github/home/cargo-target
+          key: fedora-rpm-x86_64-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            fedora-rpm-x86_64-
 
       - name: Set up rpmbuild tree
         run: rpmdev-setuptree
@@ -211,6 +223,70 @@ jobs:
         env:
           OPENSSL_NO_VENDOR: "1"
           LIBZ_SYS_USE_PKG_CONFIG: "1"
+          CARGO_TARGET_DIR: /github/home/cargo-target
+        run: rpmbuild -ba susshi.spec
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          rpm_file=$(find /github/home/rpmbuild/RPMS -name "susshi-*.rpm" | grep -v debug | head -n1)
+          dnf install -y "${rpm_file}"
+          susshi --version
+          rpm -e susshi
+
+      - name: Upload to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: /github/home/rpmbuild/RPMS/**/*.rpm
+          file_glob: true
+          tag: ${{ github.event.inputs.tag || github.ref }}
+          overwrite: true
+
+  build-rpm-aarch64:
+    name: RPM package (aarch64)
+    runs-on: ubuntu-24.04-arm
+    container: fedora:latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install build dependencies
+        run: dnf install -y rust cargo openssl-devel zlib-devel pkgconf-pkg-config rpm-build rpmdevtools git
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            /github/home/.cargo/registry/index
+            /github/home/.cargo/registry/cache
+            /github/home/.cargo/git/db
+            /github/home/cargo-target
+          key: fedora-rpm-aarch64-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            fedora-rpm-aarch64-
+
+      - name: Set up rpmbuild tree
+        run: rpmdev-setuptree
+
+      - name: Patch version in spec file
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          sed -i "s/^Version:.*/Version:        ${VERSION}/" susshi.spec
+
+      - name: Fetch source archive
+        run: spectool -g -R susshi.spec
+
+      - name: Build RPM
+        env:
+          OPENSSL_NO_VENDOR: "1"
+          LIBZ_SYS_USE_PKG_CONFIG: "1"
+          CARGO_TARGET_DIR: /github/home/cargo-target
         run: rpmbuild -ba susshi.spec
 
       - name: Smoke test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          shared-key: ${{ matrix.target }}
 
       - name: Install Linux build deps
         if: contains(matrix.target, 'unknown-linux')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
             binary_name: susshi
             asset_name: susshi-macos-apple-silicon
             openssl_mode: system
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            binary_name: susshi
+            asset_name: susshi-linux-aarch64
+            openssl_mode: system
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: susshi.exe
@@ -77,11 +82,14 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Install Linux build deps
-        if: startsWith(matrix.target, 'x86_64-unknown-linux-')
+        if: contains(matrix.target, 'unknown-linux')
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools pkg-config libssl-dev
+          sudo apt-get install -y pkg-config libssl-dev
+          if [[ "${{ matrix.target }}" == *musl* ]]; then
+            sudo apt-get install -y musl-tools
+          fi
 
       - name: Install OpenSSL (Windows)
         if: matrix.os == 'windows-latest'
@@ -206,69 +214,6 @@ jobs:
           key: fedora-rpm-x86_64-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             fedora-rpm-x86_64-
-
-      - name: Set up rpmbuild tree
-        run: rpmdev-setuptree
-
-      - name: Patch version in spec file
-        run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
-          VERSION="${TAG#v}"
-          sed -i "s/^Version:.*/Version:        ${VERSION}/" susshi.spec
-
-      - name: Fetch source archive
-        run: spectool -g -R susshi.spec
-
-      - name: Build RPM
-        env:
-          OPENSSL_NO_VENDOR: "1"
-          LIBZ_SYS_USE_PKG_CONFIG: "1"
-          CARGO_TARGET_DIR: /github/home/cargo-target
-        run: rpmbuild -ba susshi.spec
-
-      - name: Smoke test
-        shell: bash
-        run: |
-          rpm_file=$(find /github/home/rpmbuild/RPMS -name "susshi-*.rpm" | grep -v debug | head -n1)
-          dnf install -y "${rpm_file}"
-          susshi --version
-          rpm -e susshi
-
-      - name: Upload to GitHub Release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /github/home/rpmbuild/RPMS/**/*.rpm
-          file_glob: true
-          tag: ${{ github.event.inputs.tag || github.ref }}
-          overwrite: true
-
-  build-rpm-aarch64:
-    name: RPM package (aarch64)
-    runs-on: ubuntu-24.04-arm
-    container: fedora:latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
-
-      - name: Install build dependencies
-        run: dnf install -y rust cargo openssl-devel zlib-devel pkgconf-pkg-config rpm-build rpmdevtools git
-
-      - name: Cache Cargo registry and build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            /github/home/.cargo/registry/index
-            /github/home/.cargo/registry/cache
-            /github/home/.cargo/git/db
-            /github/home/cargo-target
-          key: fedora-rpm-aarch64-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            fedora-rpm-aarch64-
 
       - name: Set up rpmbuild tree
         run: rpmdev-setuptree

--- a/PKGBUILD.bin
+++ b/PKGBUILD.bin
@@ -9,12 +9,12 @@ arch=('x86_64')
 provides=('susshi')
 conflicts=('susshi')
 source=("https://github.com/yatoub/susshi/archive/refs/tags/v${pkgver}.tar.gz")
-source_x86_64=("susshi-${pkgver}-linux-amd64::https://github.com/yatoub/susshi/releases/download/v${pkgver}/susshi-linux-amd64")
+source_x86_64=("susshi-${pkgver}-linux-x86_64::https://github.com/yatoub/susshi/releases/download/v${pkgver}/susshi-linux-x86_64")
 b2sums=('cf3fa1165d6c0a1a848486b8002cd5440fc5b42d64793d3912ca9274d34172be276e8ea819ca36adeddbeeeb5ae65f29a4b8c63a7f27800fc7de94405a71e7c0')
 b2sums_x86_64=('fb145980e8acd7ed65998e4f52c4eb5e0ff6af87767d7475c6c0d1b00cd5dda20e1d16bff227800e0c1cddd56234783772bc60830dca34ec08c7e0b07d7a601f')
 
 package() {
-    install -Dm0755 "susshi-${pkgver}-linux-amd64" "$pkgdir/usr/bin/susshi"
+    install -Dm0755 "susshi-${pkgver}-linux-x86_64" "$pkgdir/usr/bin/susshi"
     install -Dm0644 "susshi-${pkgver}/LICENCE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -Dm0644 "susshi-${pkgver}/README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
     (cd "susshi-${pkgver}" && find docs/ -type f -exec install -Dm0644 {} "$pkgdir/usr/share/doc/$pkgname/{}" \;)

--- a/susshi.spec
+++ b/susshi.spec
@@ -34,7 +34,7 @@ export LIBZ_SYS_USE_PKG_CONFIG=1
 cargo test --frozen
 
 %install
-install -Dm0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
+install -Dm0755 "${CARGO_TARGET_DIR:-target}/release/%{name}" %{buildroot}%{_bindir}/%{name}
 install -Dm0644 target/man/%{name}.1 %{buildroot}%{_mandir}/man1/%{name}.1
 install -Dm0644 README.md %{buildroot}%{_docdir}/%{name}/README.md
 cp -r docs/ %{buildroot}%{_docdir}/%{name}/docs/


### PR DESCRIPTION
## Summary

Two complementary mechanisms to eliminate manual branch cleanup:

### 1. Repository setting — `delete_branch_on_merge`
Already enabled via `gh api PATCH`. GitHub now auto-deletes the head branch whenever any PR is merged. Covers all `fix/*`, `feat/*`, `ci/*`, `refactor/*`, `test/*` branches at zero CI cost.

### 2. `cleanup-branches` job in `release.yml`
release-plz closes (but does not delete) superseded release-plz branches when a newer release PR is opened. This job runs after each tag push and deletes every `release-plz-*` branch that has no open PR:

```bash
gh api repos/{repo}/branches --paginate \
  --jq '.[].name | select(startswith("release-plz-"))' \
| while read branch; do
    open=$(gh pr list --head "$branch" --state open ...)
    [ "$open" = "0" ] && gh api -X DELETE .../refs/heads/$branch
  done
```

Safety: only deletes branches with **no open PR** — the current release-plz PR branch is always preserved.

## Test plan
- [ ] Merge a PR → branch auto-deleted by GitHub
- [ ] After the next release, confirm `cleanup-branches` job deletes all stale `release-plz-*` branches in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)