### PR TITLE
ci: auto-delete branches after merge + cleanup stale release-plz branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,3 +303,27 @@ jobs:
           VERSION="${TAG#v}"
           git commit -m "chore(release): update PKGBUILD to v${VERSION}"
           git push
+
+  # ── Cleanup stale release-plz branches ───────────────────────────────────
+
+  cleanup-branches:
+    name: Cleanup stale release-plz branches
+    runs-on: ubuntu-latest
+    needs: [update-pkgbuild]
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - name: Delete closed release-plz branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/branches" --paginate \
+            --jq '.[].name | select(startswith("release-plz-"))' \
+          | while IFS= read -r branch; do
+              open=$(gh pr list --head "$branch" --state open --json number --jq 'length')
+              if [ "$open" = "0" ]; then
+                gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$branch" \
+                  && echo "Deleted: $branch" || true
+              fi
+            done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,8 @@ jobs:
           | while IFS= read -r branch; do
               open=$(gh pr list --head "$branch" --state open --json number --jq 'length')
               if [ "$open" = "0" ]; then
-                gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$branch" \
-                  && echo "Deleted: $branch" || true
+                if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$branch" 2>/dev/null; then
+                  echo "Deleted: $branch"
+                fi
               fi
             done


### PR DESCRIPTION
## Summary

Two complementary mechanisms to eliminate manual branch cleanup:

### 1. Repository setting — `delete_branch_on_merge`
Already enabled via `gh api PATCH`. GitHub now auto-deletes the head branch whenever any PR is merged. Covers all `fix/*`, `feat/*`, `ci/*`, `refactor/*`, `test/*` branches at zero CI cost.

### 2. `cleanup-branches` job in `release.yml`
release-plz closes (but does not delete) superseded release-plz branches when a newer release PR is opened. This job runs after each tag push and deletes every `release-plz-*` branch that has no open PR:

```bash
gh api repos/{repo}/branches --paginate \
  --jq '.[].name | select(startswith("release-plz-"))' \
| while read branch; do
    open=$(gh pr list --head "$branch" --state open ...)
    [ "$open" = "0" ] && gh api -X DELETE .../refs/heads/$branch
  done
```

Safety: only deletes branches with **no open PR** — the current release-plz PR branch is always preserved.

## Test plan
- [ ] Merge a PR → branch auto-deleted by GitHub
- [ ] After the next release, confirm `cleanup-branches` job deletes all stale `release-plz-*` branches in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)