### PR TITLE
fix(ci): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,11 @@ targets = []
 [advisories]
 version = 2
 yanked = "deny"
+ignore = [
+    # proc-macro-error2 is unmaintained (RUSTSEC-2026-0173); transitive dep of
+    # i18n-embed-fl with no safe upgrade available upstream.
+    "RUSTSEC-2026-0173",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

- Adds `RUSTSEC-2026-0173` to the `deny.toml` ignore list
- `proc-macro-error2` is a transitive dependency of `i18n-embed-fl` and has been confirmed unmaintained by its author with no safe upgrade available
- This unblocks the ratatui 0.30.1 Dependabot PR (#134) which fails `Security (cargo deny)`

## Test plan

- [ ] CI `Security (cargo deny)` job passes on this PR
- [ ] After merge, trigger a rebase on PR #134 to confirm it also passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)