### PR TITLE
chore: release v0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal SSH manager with YAML inventories, multi-hop jump hosts, Wallix bastion, tunnels, SCP, and Catppuccin TUI"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.18.1 -> 0.18.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.18.1] — 2026-05-29

### Fixed

- Fix(aur) + feat(ci): fix susshi-bin binary name, cache RPM builds, add aarch64 RPM ([#123](https://github.com/yatoub/susshi/pull/123))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).