### PR TITLE
feat: limit include recursion to 2 levels and warn on outdated include repos

### DIFF
--- a/i18n/en/susshi.ftl
+++ b/i18n/en/susshi.ftl
@@ -103,6 +103,7 @@ wallix-selector-list-hint = ↑/↓: navigate | Enter: connect | Esc/q: cancel
 include-warn-load = Failed to load '{ $label }' ({ $path }) : { $error }
 include-warn-circular = Circular dependency ignored: '{ $label }' ({ $path })
 include-warn-nested = Nested includes in '{ $label }' are ignored (v0.7)
+include-warn-git-outdated = Git repository '{ $path }' is { $behind } commit(s) behind its upstream branch — consider running git pull.
 
 # ── Status messages ───────────────────────────────────────────────────────────
 copied = Copied: { $cmd }

--- a/i18n/fr/susshi.ftl
+++ b/i18n/fr/susshi.ftl
@@ -103,6 +103,7 @@ wallix-selector-list-hint = ↑/↓ : naviguer | Entrée : connecter | Esc/q : a
 include-warn-load = Impossible de charger '{ $label }' ({ $path }) : { $error }
 include-warn-circular = Dépendance circulaire ignorée : '{ $label }' ({ $path })
 include-warn-nested = Les includes imbriqués dans '{ $label }' sont ignorés (v0.7)
+include-warn-git-outdated = Le dépôt git '{ $path }' a { $behind } commit(s) de retard sur sa branche amont — pensez à faire un git pull.
 
 # ── Messages de statut ────────────────────────────────────────────────────────
 copied = Copié : { $cmd }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -136,6 +136,13 @@ impl App {
                             path = path.as_str()
                         )
                     }
+                    crate::config::IncludeWarning::GitOutdated { path, behind } => {
+                        fl!(
+                            "include-warn-git-outdated",
+                            path = path.as_str(),
+                            behind = (*behind as i64)
+                        )
+                    }
                 })
                 .collect();
             app.app_mode = AppMode::Error(lines.join("\n"));
@@ -147,8 +154,9 @@ impl App {
     /// Reloads configuration from disk without restarting the app.
     pub fn reload(&mut self) -> Result<(), ConfigError> {
         let mut stack = std::collections::HashSet::new();
-        let (new_config, new_warnings, new_val_warnings) =
+        let (new_config, mut new_warnings, new_val_warnings) =
             Config::load_merged(&self.config_path, &mut stack, 0)?;
+        new_warnings.extend(crate::config::git_outdated_warnings(&new_config));
         let resolved = new_config.resolve()?;
 
         self.config_hash = hash_config_file(&self.config_path);

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,10 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-const MAX_INCLUDE_DEPTH: u32 = 8;
+// 2 niveaux d'includes imbriqués (fichier principal → include → include de
+// l'include), pas plus : au-delà, les chaînes de configuration deviennent
+// difficiles à suivre.
+const MAX_INCLUDE_DEPTH: u32 = 2;
 const MAX_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024; // 5 MiB
 const HTTP_TIMEOUT_SECS: u64 = 10;
 
@@ -26,6 +29,10 @@ pub use interpolate::{interpolate, undefined_vars};
 mod validate;
 pub(crate) use validate::fetch_url;
 pub use validate::validate_yaml;
+
+#[path = "config/git_status.rs"]
+mod git_status;
+pub use git_status::git_outdated_warnings;
 
 #[cfg(test)]
 #[path = "config/tests.rs"]

--- a/src/config/git_status.rs
+++ b/src/config/git_status.rs
@@ -1,0 +1,83 @@
+use super::*;
+use std::process::Command;
+
+/// Résout la racine du dépôt git contenant `start_dir`, si `start_dir` (ou un de
+/// ses parents) se trouve dans un working tree git. Retourne `None` sans erreur
+/// si `git` est absent, si le chemin n'est pas un dépôt, ou pour tout autre échec —
+/// cette vérification est un bonus best-effort, jamais une condition bloquante.
+fn git_repo_toplevel(start_dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(start_dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+/// Nombre de commits dont `HEAD` est en retard sur sa branche amont (`@{upstream}`),
+/// déterminé uniquement à partir des refs déjà connues localement — n'effectue
+/// jamais de `git fetch`. Retourne `None` si aucune branche amont n'est configurée
+/// ou en cas d'échec.
+fn git_behind_count(repo_toplevel: &Path) -> Option<u32> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_toplevel)
+        .args(["rev-list", "--count", "HEAD..@{upstream}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .parse::<u32>()
+        .ok()
+}
+
+/// Calcule les avertissements « dépôt git en retard » pour tous les includes
+/// locaux résolus dans `config` (namespaces issus de `Config::load_merged`).
+/// Un seul avertissement par dépôt git, même si plusieurs includes proviennent
+/// du même checkout. Les includes HTTPS sont ignorés (rien à vérifier localement).
+pub fn git_outdated_warnings(config: &Config) -> Vec<IncludeWarning> {
+    let mut cache: HashMap<PathBuf, Option<u32>> = HashMap::new();
+    let mut warned: HashSet<PathBuf> = HashSet::new();
+    let mut warnings = Vec::new();
+
+    for entry in &config.groups {
+        let ConfigEntry::Namespace(ns) = entry else {
+            continue;
+        };
+        if ns.source_path.starts_with("http://") || ns.source_path.starts_with("https://") {
+            continue;
+        }
+        let Some(parent) = Path::new(&ns.source_path).parent() else {
+            continue;
+        };
+        let Some(toplevel) = git_repo_toplevel(parent) else {
+            continue;
+        };
+
+        let behind = *cache
+            .entry(toplevel.clone())
+            .or_insert_with(|| git_behind_count(&toplevel));
+
+        if let Some(behind) = behind
+            && behind > 0
+            && warned.insert(toplevel.clone())
+        {
+            warnings.push(IncludeWarning::GitOutdated {
+                path: toplevel.display().to_string(),
+                behind,
+            });
+        }
+    }
+
+    warnings
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1899,6 +1899,104 @@ fn test_include_depth_at_limit() {
 }
 
 #[test]
+fn test_include_two_levels_of_nesting_allowed() {
+    // main → A → B (B a des serveurs, pas d'includes) : exactement 2 niveaux
+    // d'includes imbriqués, doit réussir.
+    let leaf_yaml = r#"
+groups:
+  - name: Leaf
+    servers:
+      - name: leaf_srv
+        host: "203.0.113.9"
+"#;
+    let leaf_file = write_temp_yaml(leaf_yaml);
+
+    let sub_yaml = format!(
+        r#"
+includes:
+  - label: "B"
+    path: "{}"
+groups: []
+"#,
+        leaf_file.path().to_string_lossy()
+    );
+    let sub_file = write_temp_yaml(&sub_yaml);
+
+    let main_yaml = format!(
+        r#"
+includes:
+  - label: "A"
+    path: "{}"
+groups: []
+"#,
+        sub_file.path().to_string_lossy()
+    );
+    let main_file = write_temp_yaml(&main_yaml);
+
+    let (config, warnings, _val) =
+        Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0).unwrap();
+    assert!(
+        warnings.is_empty(),
+        "Expected no warnings, got: {:?}",
+        warnings
+    );
+    let resolved = config.resolve().unwrap();
+    assert!(
+        resolved
+            .iter()
+            .any(|s| s.name == "leaf_srv" && s.namespace == "A / B")
+    );
+}
+
+#[test]
+fn test_include_three_levels_of_nesting_rejected() {
+    // main → A → B → C : un 3ᵉ niveau d'includes imbriqués dépasse la limite
+    // (2) et doit être rejeté avec une erreur explicite, pas un avertissement.
+    let leaf_yaml = "groups: []\n";
+    let leaf_file = write_temp_yaml(leaf_yaml);
+
+    let c_yaml = format!(
+        r#"
+includes:
+  - label: "C"
+    path: "{}"
+groups: []
+"#,
+        leaf_file.path().to_string_lossy()
+    );
+    let c_file = write_temp_yaml(&c_yaml);
+
+    let b_yaml = format!(
+        r#"
+includes:
+  - label: "B"
+    path: "{}"
+groups: []
+"#,
+        c_file.path().to_string_lossy()
+    );
+    let b_file = write_temp_yaml(&b_yaml);
+
+    let a_yaml = format!(
+        r#"
+includes:
+  - label: "A"
+    path: "{}"
+groups: []
+"#,
+        b_file.path().to_string_lossy()
+    );
+    let a_file = write_temp_yaml(&a_yaml);
+
+    let err =
+        Config::load_merged(a_file.path(), &mut std::collections::HashSet::new(), 0).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::IncludeDepthExceeded { .. }),
+        "expected IncludeDepthExceeded, got: {err}"
+    );
+}
+
+#[test]
 fn test_fetch_url_rejects_http_scheme() {
     // https_only(true) rejects http:// before any network call — no mocking needed.
     let result = fetch_url("http://example.com/config.yaml");
@@ -1909,5 +2007,216 @@ fn test_fetch_url_rejects_http_scheme() {
             || msg.to_lowercase().contains("https")
             || msg.to_lowercase().contains("plain"),
         "error message should mention the scheme issue, got: {msg}"
+    );
+}
+
+// ─── Tests git_outdated_warnings (issue #196) ─────────────────────────────────
+
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("failed to spawn git");
+    assert!(
+        output.status.success(),
+        "git -C {} {:?} failed: {}",
+        dir.display(),
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_repo_with_commit(dir: &std::path::Path) {
+    std::fs::create_dir_all(dir).unwrap();
+    run_git(dir, &["init", "-b", "main"]);
+    run_git(dir, &["config", "user.email", "test@example.com"]);
+    run_git(dir, &["config", "user.name", "Test"]);
+    std::fs::write(dir.join("susshi.yml"), "groups: []\n").unwrap();
+    run_git(dir, &["add", "susshi.yml"]);
+    run_git(dir, &["commit", "-m", "initial"]);
+}
+
+fn namespace_for(label: &str, source_path: &std::path::Path) -> ConfigEntry {
+    ConfigEntry::Namespace(NamespaceEntry {
+        label: label.to_string(),
+        source_path: source_path.display().to_string(),
+        defaults: None,
+        entries: vec![],
+        vars: HashMap::new(),
+    })
+}
+
+#[test]
+fn test_git_outdated_warns_when_behind() {
+    let dir = tempfile::tempdir().unwrap();
+    let bare = dir.path().join("remote.git");
+    let checkout = dir.path().join("checkout");
+    let other = dir.path().join("other");
+
+    run_git(dir.path(), &["init", "--bare", bare.to_str().unwrap()]);
+
+    init_repo_with_commit(&checkout);
+    run_git(
+        &checkout,
+        &["remote", "add", "origin", bare.to_str().unwrap()],
+    );
+    run_git(&checkout, &["push", "-u", "origin", "main"]);
+
+    // Second clone pushes an extra commit that `checkout` doesn't have yet.
+    run_git(
+        dir.path(),
+        &["clone", bare.to_str().unwrap(), other.to_str().unwrap()],
+    );
+    // The bare repo's default HEAD may not point at "main" (it depends on
+    // git's default-branch config at `init --bare` time, not on what was
+    // pushed) — check out the branch explicitly via its remote-tracking ref.
+    run_git(&other, &["checkout", "main"]);
+    run_git(&other, &["config", "user.email", "test@example.com"]);
+    run_git(&other, &["config", "user.name", "Test"]);
+    std::fs::write(other.join("extra.txt"), "x").unwrap();
+    run_git(&other, &["add", "extra.txt"]);
+    run_git(&other, &["commit", "-m", "extra"]);
+    run_git(&other, &["push", "origin", "main"]);
+
+    // Fetch (setup only — not part of the code under test) so `checkout`'s
+    // remote-tracking ref knows about the new commit without pulling it in.
+    run_git(&checkout, &["fetch", "origin"]);
+
+    let config = Config {
+        defaults: None,
+        groups: vec![namespace_for("Sub", &checkout.join("susshi.yml"))],
+        includes: vec![],
+        vars: HashMap::new(),
+    };
+
+    let warnings = git_outdated_warnings(&config);
+    assert_eq!(
+        warnings.len(),
+        1,
+        "expected exactly one warning, got: {warnings:?}"
+    );
+    match &warnings[0] {
+        IncludeWarning::GitOutdated { behind, .. } => assert_eq!(*behind, 1),
+        other => panic!("expected GitOutdated, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_git_outdated_no_warning_when_up_to_date() {
+    let dir = tempfile::tempdir().unwrap();
+    let checkout = dir.path().join("checkout");
+    init_repo_with_commit(&checkout);
+
+    let config = Config {
+        defaults: None,
+        groups: vec![namespace_for("Sub", &checkout.join("susshi.yml"))],
+        includes: vec![],
+        vars: HashMap::new(),
+    };
+
+    assert!(git_outdated_warnings(&config).is_empty());
+}
+
+#[test]
+fn test_git_outdated_no_warning_without_upstream() {
+    let dir = tempfile::tempdir().unwrap();
+    let checkout = dir.path().join("checkout");
+    // Repo with a commit but no remote configured at all.
+    init_repo_with_commit(&checkout);
+
+    let config = Config {
+        defaults: None,
+        groups: vec![namespace_for("Sub", &checkout.join("susshi.yml"))],
+        includes: vec![],
+        vars: HashMap::new(),
+    };
+
+    assert!(git_outdated_warnings(&config).is_empty());
+}
+
+#[test]
+fn test_git_outdated_no_warning_for_non_git_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("susshi.yml"), "groups: []\n").unwrap();
+
+    let config = Config {
+        defaults: None,
+        groups: vec![namespace_for("Sub", &dir.path().join("susshi.yml"))],
+        includes: vec![],
+        vars: HashMap::new(),
+    };
+
+    assert!(git_outdated_warnings(&config).is_empty());
+}
+
+#[test]
+fn test_git_outdated_skips_http_includes() {
+    let config = Config {
+        defaults: None,
+        groups: vec![namespace_for(
+            "Remote",
+            std::path::Path::new("https://example.com/susshi.yml"),
+        )],
+        includes: vec![],
+        vars: HashMap::new(),
+    };
+
+    assert!(git_outdated_warnings(&config).is_empty());
+}
+
+#[test]
+fn test_git_outdated_dedups_same_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    let bare = dir.path().join("remote.git");
+    let checkout = dir.path().join("checkout");
+    let other = dir.path().join("other");
+
+    run_git(dir.path(), &["init", "--bare", bare.to_str().unwrap()]);
+
+    init_repo_with_commit(&checkout);
+    std::fs::write(checkout.join("second.yml"), "groups: []\n").unwrap();
+    run_git(&checkout, &["add", "second.yml"]);
+    run_git(&checkout, &["commit", "-m", "second file"]);
+    run_git(
+        &checkout,
+        &["remote", "add", "origin", bare.to_str().unwrap()],
+    );
+    run_git(&checkout, &["push", "-u", "origin", "main"]);
+
+    run_git(
+        dir.path(),
+        &["clone", bare.to_str().unwrap(), other.to_str().unwrap()],
+    );
+    // The bare repo's default HEAD may not point at "main" (it depends on
+    // git's default-branch config at `init --bare` time, not on what was
+    // pushed) — check out the branch explicitly via its remote-tracking ref.
+    run_git(&other, &["checkout", "main"]);
+    run_git(&other, &["config", "user.email", "test@example.com"]);
+    run_git(&other, &["config", "user.name", "Test"]);
+    std::fs::write(other.join("extra.txt"), "x").unwrap();
+    run_git(&other, &["add", "extra.txt"]);
+    run_git(&other, &["commit", "-m", "extra"]);
+    run_git(&other, &["push", "origin", "main"]);
+
+    run_git(&checkout, &["fetch", "origin"]);
+
+    // Two includes from the same checkout must yield a single warning.
+    let config = Config {
+        defaults: None,
+        groups: vec![
+            namespace_for("Sub A", &checkout.join("susshi.yml")),
+            namespace_for("Sub B", &checkout.join("second.yml")),
+        ],
+        includes: vec![],
+        vars: HashMap::new(),
+    };
+
+    let warnings = git_outdated_warnings(&config);
+    assert_eq!(
+        warnings.len(),
+        1,
+        "expected deduped warning, got: {warnings:?}"
     );
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -110,6 +110,9 @@ pub enum IncludeWarning {
     },
     /// Dépendance circulaire détectée.
     Circular { label: String, path: String },
+    /// Le dépôt git contenant le fichier inclus a des commits en retard sur
+    /// sa branche amont (détecté sans `git fetch`, à partir des refs locales).
+    GitOutdated { path: String, behind: u32 },
 }
 
 /// Avertissement émis lors de la validation YAML — champ inconnu ou inattendu.

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,9 @@ fn validate_config(config_path: &std::path::Path) {
             eprintln!("ERREUR : {e}");
             process::exit(1);
         }
-        Ok((config, inc_warnings, val_warnings)) => {
+        Ok((config, mut inc_warnings, val_warnings)) => {
             let mut has_error = false;
+            inc_warnings.extend(susshi::config::git_outdated_warnings(&config));
 
             for w in &inc_warnings {
                 match w {
@@ -71,6 +72,9 @@ fn validate_config(config_path: &std::path::Path) {
                     }
                     IncludeWarning::Circular { label, path } => {
                         eprintln!("[WARN  circular] {label} ({path})");
+                    }
+                    IncludeWarning::GitOutdated { path, behind } => {
+                        eprintln!("[WARN  git]     {path}: {behind} commit(s) de retard");
                     }
                 }
             }
@@ -515,7 +519,7 @@ fn main() -> io::Result<()> {
         return Err(e);
     }
 
-    let (config, warnings, val_warnings) =
+    let (config, mut warnings, val_warnings) =
         match Config::load_merged(config_path, &mut HashSet::new(), 0) {
             Ok(c) => c,
             Err(e) => {
@@ -523,6 +527,7 @@ fn main() -> io::Result<()> {
                 return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
             }
         };
+    warnings.extend(susshi::config::git_outdated_warnings(&config));
 
     // ── Modes non-TUI ──────────────────────────────────────────────────────
     if cli.export.is_some() {


### PR DESCRIPTION
## Summary
- Lowers `MAX_INCLUDE_DEPTH` from 8 to 2: an include may itself include another (one level of nesting), but no deeper — a 3rd-level nested include now fails fast with `IncludeDepthExceeded` instead of resolving silently.
- Closes #196: warns (non-blocking) when a local include's git checkout has commits it hasn't pulled from its upstream, shown alongside the existing include warnings at TUI startup, on config reload, and in `--validate`. Detection is purely local (`git rev-list --count HEAD..@{upstream}`, no `git fetch`), deduped per repository root, and silently skipped whenever `git` is unavailable, the path isn't a repo, or no upstream is configured.

## Test plan
- [x] `cargo test` — 440 lib tests pass, including new coverage for both features (2-vs-3-level include nesting, and git-outdated: behind / up-to-date / no-upstream / non-repo / http-include-skip / dedup-per-repo, using real temp git repos)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual smoke test via `susshi --validate` against a real behind/up-to-date git fixture — warning fires with the correct commit count, disappears after `git pull`, exit code stays 0 (non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZc4R4v75j7CrPEfhehrEh