### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.22.0] — 2026-08-18
+
+### Added
+
+- Limit include recursion to 2 levels and warn on outdated include repos ([#197](https://github.com/yatoub/susshi/pull/197))
+
+
 ## [0.21.1] — 2026-08-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal SSH manager with YAML inventories, multi-hop jump hosts, Wallix bastion, tunnels, SCP, and Catppuccin TUI"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.21.1 -> 0.22.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.0] — 2026-08-18

### Added

- Limit include recursion to 2 levels and warn on outdated include repos ([#197](https://github.com/yatoub/susshi/pull/197))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).