### PR TITLE
ci: add smoke test for susshi-bin install from AUR

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -149,3 +149,55 @@ jobs:
           github-token: ${{ github.token }}
           title: "AUR publish (susshi-bin) failed for ${{ steps.ver.outputs.tag || 'unknown' }}"
           body: "aur-bin failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # ── Smoke test: susshi-bin install from AUR ───────────────────────────────
+
+  smoke-test-aur-bin:
+    name: Smoke test — AUR susshi-bin install
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [aur-bin]
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install susshi-bin from AUR (retry for AUR propagation delay)
+        run: |
+          cat > smoke-test.sh <<'SCRIPT'
+          set -e
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed base-devel git
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+          su - builder -c '
+            set -e
+            git clone https://aur.archlinux.org/susshi-bin.git /home/builder/susshi-bin
+            cd /home/builder/susshi-bin
+            makepkg -si --noconfirm
+            susshi --version
+          '
+          SCRIPT
+
+          for attempt in 1 2 3 4 5; do
+            if docker run --rm \
+                -v "${{ github.workspace }}/smoke-test.sh:/smoke-test.sh:ro" \
+                archlinux:base-devel \
+                bash /smoke-test.sh; then
+              exit 0
+            fi
+            echo "Attempt $attempt failed, retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::susshi-bin failed to install from AUR after 5 attempts"
+          exit 1
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          github-token: ${{ github.token }}
+          title: "AUR susshi-bin smoke test failed for ${{ github.event.inputs.tag }}"
+          body: "A fresh 'makepkg -si' for susshi-bin from AUR failed for ${{ github.event.inputs.tag }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary
- Adds `smoke-test-aur-bin` to `aur-publish.yml`, `needs: [aur-bin]`, mirroring `smoke-test-apt` in `release.yml`.
- Runs `makepkg -si` for `susshi-bin` in a fresh `archlinux:base-devel` container (as a non-root user, since `makepkg` refuses root): clones the AUR repo, builds/installs (which fetches the released binary and verifies its b2sum), then checks `susshi --version`.
- Retries up to 5 times with a 60s backoff for AUR propagation delay, and opens a `ci-failure`-labeled issue via the shared `notify-failure` action on exhaustion — same pattern as the APT smoke test.

## Test plan
- [x] Ran the embedded script locally in `archlinux:base-devel` via `docker run` against the live `susshi-bin` AUR package (v0.22.0): resolved, verified b2sums, built, installed, and `susshi --version` printed `susshi 0.22.0`.
- [ ] CI run on this PR will exercise the YAML/job wiring (the job itself only triggers for `workflow_dispatch` runs of `aur-publish.yml`, so it won't run on this PR's push — the next real AUR publish will be the first live run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZc4R4v75j7CrPEfhehrEh