### PR TITLE
fix: skip empty umbrella namespace for includes-only files

### DIFF
--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -191,15 +191,22 @@ impl Config {
                         other => direct_entries.push(other),
                     }
                 }
-                config.groups.push(ConfigEntry::Namespace(NamespaceEntry {
-                    label: entry.label.clone(),
-                    source_path: url.clone(),
-                    defaults: sub_config.defaults,
-                    entries: direct_entries,
-                    vars: sub_config.vars,
-                }));
+                // Un fichier inclus ne contenant lui-même que des `!include` (aucune
+                // entrée directe) ne produit pas de nœud "parapluie" vide dans l'arbre.
+                if !direct_entries.is_empty() {
+                    push_namespace(
+                        &mut config.groups,
+                        NamespaceEntry {
+                            label: entry.label.clone(),
+                            source_path: url.clone(),
+                            defaults: sub_config.defaults,
+                            entries: direct_entries,
+                            vars: sub_config.vars,
+                        },
+                    );
+                }
                 for nested in nested_namespaces {
-                    config.groups.push(ConfigEntry::Namespace(nested));
+                    push_namespace(&mut config.groups, nested);
                 }
                 continue;
             }
@@ -269,24 +276,34 @@ impl Config {
                 }
             }
 
-            // Namespace principal avec les entrées directes
-            config.groups.push(ConfigEntry::Namespace(NamespaceEntry {
-                label: entry.label.clone(),
-                source_path: sub_canonical.display().to_string(),
-                defaults: sub_config.defaults,
-                entries: direct_entries,
-                vars: sub_config.vars.clone(),
-            }));
+            // Namespace principal avec les entrées directes. Un fichier inclus ne
+            // contenant lui-même que des `!include` (aucune entrée directe) ne
+            // produit pas de nœud "parapluie" vide dans l'arbre.
+            if !direct_entries.is_empty() {
+                push_namespace(
+                    &mut config.groups,
+                    NamespaceEntry {
+                        label: entry.label.clone(),
+                        source_path: sub_canonical.display().to_string(),
+                        defaults: sub_config.defaults,
+                        entries: direct_entries,
+                        vars: sub_config.vars.clone(),
+                    },
+                );
+            }
 
             // Namespaces imbriqués aplatis avec label préfixé "parent / enfant"
             for nested in nested_namespaces {
-                config.groups.push(ConfigEntry::Namespace(NamespaceEntry {
-                    label: format!("{} / {}", entry.label, nested.label),
-                    source_path: nested.source_path,
-                    defaults: nested.defaults,
-                    entries: nested.entries,
-                    vars: nested.vars,
-                }));
+                push_namespace(
+                    &mut config.groups,
+                    NamespaceEntry {
+                        label: format!("{} / {}", entry.label, nested.label),
+                        source_path: nested.source_path,
+                        defaults: nested.defaults,
+                        entries: nested.entries,
+                        vars: nested.vars,
+                    },
+                );
             }
         }
 
@@ -295,6 +312,28 @@ impl Config {
 
         Ok((config, inc_warnings, val_warnings))
     }
+}
+
+/// Ajoute un `NamespaceEntry` à `groups`, en le fusionnant avec un namespace existant
+/// de même `label` plutôt que de créer un doublon dans l'arborescence.
+///
+/// Deux `!include` distincts (ou un include imbriqué et un include direct) peuvent
+/// légitimement partager le même label (ex. deux fichiers sous "CES 3S") ; sans
+/// fusion, chacun produisait un nœud racine séparé dans l'arbre affiché.
+fn push_namespace(groups: &mut Vec<ConfigEntry>, ns: NamespaceEntry) {
+    for entry in groups.iter_mut() {
+        if let ConfigEntry::Namespace(existing) = entry
+            && existing.label == ns.label
+        {
+            existing.entries.extend(ns.entries);
+            existing.vars.extend(ns.vars);
+            if existing.defaults.is_none() {
+                existing.defaults = ns.defaults;
+            }
+            return;
+        }
+    }
+    groups.push(ConfigEntry::Namespace(ns));
 }
 
 /// Résout un slice d'entrées de configuration avec les defaults et le namespace donnés.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -628,6 +628,133 @@ groups:
 }
 
 #[test]
+fn test_includes_duplicate_label_merges_into_single_namespace() {
+    // Deux fichiers inclus séparément sous le même label doivent produire
+    // un seul nœud Namespace dans l'arbre, avec les entrées des deux fusionnées.
+    let sub_a_yaml = r#"
+groups:
+  - name: Group_A
+    servers:
+      - name: srv_a
+        host: "198.51.100.1"
+"#;
+    let sub_b_yaml = r#"
+groups:
+  - name: Group_B
+    servers:
+      - name: srv_b
+        host: "198.51.100.2"
+"#;
+    let sub_a_file = write_temp_yaml(sub_a_yaml);
+    let sub_b_file = write_temp_yaml(sub_b_yaml);
+
+    let main_yaml = format!(
+        r#"
+includes:
+  - label: "CES 3S"
+    path: "{}"
+  - label: "CES 3S"
+    path: "{}"
+"#,
+        sub_a_file.path().to_string_lossy(),
+        sub_b_file.path().to_string_lossy()
+    );
+    let main_file = write_temp_yaml(&main_yaml);
+
+    let (config, warnings, _val) =
+        Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0).unwrap();
+    assert!(warnings.is_empty(), "Expected no warnings: {:?}", warnings);
+
+    let namespaces: Vec<_> = config
+        .groups
+        .iter()
+        .filter_map(|e| match e {
+            ConfigEntry::Namespace(ns) if ns.label == "CES 3S" => Some(ns),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        namespaces.len(),
+        1,
+        "Expected a single merged Namespace(CES 3S), got {}",
+        namespaces.len()
+    );
+    assert_eq!(namespaces[0].entries.len(), 2);
+
+    let resolved = config.resolve().unwrap();
+    assert!(resolved.iter().any(|s| s.name == "srv_a"));
+    assert!(resolved.iter().any(|s| s.name == "srv_b"));
+}
+
+#[test]
+fn test_includes_only_file_omits_empty_umbrella_namespace() {
+    // Un fichier racine qui ne fait que `!include` d'autres fichiers, sans
+    // `groups:` explicite ni entrée directe, ne doit produire ni erreur de
+    // parsing ni nœud "CES 3S" vide dans l'arbre : seuls les sous-namespaces
+    // "CES 3S / Colibris" et "CES 3S / Scolarité" doivent apparaître.
+    let colibris_yaml = r#"
+groups:
+  - name: COLIBRIS
+    servers:
+      - name: colibris_srv
+        host: "198.51.100.10"
+"#;
+    let scolarite_yaml = r#"
+groups:
+  - name: SCOLARITE
+    servers:
+      - name: scolarite_srv
+        host: "198.51.100.11"
+"#;
+    let colibris_file = write_temp_yaml(colibris_yaml);
+    let scolarite_file = write_temp_yaml(scolarite_yaml);
+
+    let umbrella_yaml = format!(
+        r#"
+includes:
+  - label: "Colibris"
+    path: "{}"
+  - label: "Scolarité"
+    path: "{}"
+"#,
+        colibris_file.path().to_string_lossy(),
+        scolarite_file.path().to_string_lossy()
+    );
+    let umbrella_file = write_temp_yaml(&umbrella_yaml);
+
+    let main_yaml = format!(
+        r#"
+includes:
+  - label: "CES 3S"
+    path: "{}"
+"#,
+        umbrella_file.path().to_string_lossy()
+    );
+    let main_file = write_temp_yaml(&main_yaml);
+
+    let (config, warnings, _val) =
+        Config::load_merged(main_file.path(), &mut std::collections::HashSet::new(), 0).unwrap();
+    assert!(warnings.is_empty(), "Expected no warnings: {:?}", warnings);
+
+    let labels: Vec<&str> = config
+        .groups
+        .iter()
+        .filter_map(|e| match e {
+            ConfigEntry::Namespace(ns) => Some(ns.label.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !labels.contains(&"CES 3S"),
+        "Empty umbrella namespace 'CES 3S' should not appear in tree, got {:?}",
+        labels
+    );
+    assert!(labels.contains(&"CES 3S / Colibris"));
+    assert!(labels.contains(&"CES 3S / Scolarité"));
+}
+
+#[test]
 fn test_includes_defaults_isolation() {
     let sub_yaml = r#"
 defaults:

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -139,6 +139,7 @@ impl fmt::Display for ValidationWarning {
 #[derive(Debug, Deserialize, Default)]
 pub struct Config {
     pub defaults: Option<Defaults>,
+    #[serde(default)]
     pub groups: Vec<ConfigEntry>,
     /// Fichiers supplémentaires à fusionner (ignoré dans les sous-fichiers).
     #[serde(default)]


### PR DESCRIPTION
## Summary
- A YAML file with only `includes:` (no `groups:`) no longer errors — `groups` is now `#[serde(default)]`.
- An included file that itself only contains `!include` directives no longer produces an empty "parapluie" namespace node in the TUI tree; only its nested namespaces (e.g. `"CES 3S / Colibris"`) show up.
- `NamespaceEntry` instances sharing the same `label` are now merged instead of pushed as duplicates.

Fixes the reported confusing tree, where a double-inclusion setup showed a stray empty `CES 3S` entry alongside `CES 3S / Colibris`, `CES 3S / Scolarité`, etc.

## Test plan
- [x] `cargo test --lib config::` — 77 passed, including 2 new regression tests
- [x] `cargo test --verbose` — full suite, 442 passed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

https://claude.ai/code/session_01WSoQKSrnCFuckqi2b6js9d